### PR TITLE
Rename references in unit tests

### DIFF
--- a/python/graphrag/tests/unit/indexing/default_config/test_default_config.py
+++ b/python/graphrag/tests/unit/indexing/default_config/test_default_config.py
@@ -136,9 +136,7 @@ class TestDefaultConfig(unittest.TestCase):
     def test_create_parameters(self) -> None:
         parameters = default_config_parameters(
             DefaultConfigParametersModel(
-                llm=LLMParametersModel(
-                    api_key="${API_KEY_X}", model="test-llm"
-                ),
+                llm=LLMParametersModel(api_key="${API_KEY_X}", model="test-llm"),
                 storage=StorageConfigModel(
                     type=PipelineStorageType.blob,
                     connection_string="test_cs",


### PR DESCRIPTION
- Make sure all gpt references are valid ones. 