### PR TITLE
Update text_embed.py to fix vector db push

### DIFF
--- a/graphrag/index/verbs/text/embed/text_embed.py
+++ b/graphrag/index/verbs/text/embed/text_embed.py
@@ -176,7 +176,7 @@ async def _text_embed_with_vector_store(
         vectors = result.embeddings or []
         documents: list[VectorStoreDocument] = []
         for id, text, title, vector in zip(ids, texts, titles, vectors, strict=True):
-            if type(vector) == np.ndarray: 
+            if type(vector) == np.ndarray:
                 vector = vector.tolist()
             document = VectorStoreDocument(
                 id=id,
@@ -185,11 +185,8 @@ async def _text_embed_with_vector_store(
                 attributes={"title": title},
             )
             documents.append(document)
-            
-        if i == 0:
-            vector_store.load_documents(documents, overwrite)
-        else:
-            vector_store.load_documents(documents, False)
+
+        vector_store.load_documents(documents, overwrite and i == 0)
         starting_index += len(documents)
         i += 1
 


### PR DESCRIPTION
## Description

If dataset is larger than batch_size for vector db insert push during text_embed, only final batch_size vectors are saved to DB. Added logic to only overwrite dataset (if overwrite is True) during first batch. Also, the output of the embedding is a numpy array, but the VectorStoreDocument class expects a list of floats. If type is np.array, use .tolist().

## Proposed Changes

Modified text_embed.py

## Checklist

- [ ] I ran the linter and fixed any issues.
- [ X ] I have tested these changes locally.
- [ ] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).
- [ ] I have assigned the pull request to the appropriate reviewer(s).
- [ ] I have run `poetry run semversioner add-change` to create a semver-impact file.

## Additional Notes

Changes only apply indexing using remote vector db.
