### PR TITLE
Fix dead link due to typo

### DIFF
--- a/docsite/posts/prompt_tuning/overview.md
+++ b/docsite/posts/prompt_tuning/overview.md
@@ -23,4 +23,4 @@ Auto Templating leverages your input data and LLM interactions to create domain 
 
 ## Manual Configuration
 
-Manual configuration is an advanced use-case. Most users will want to use the Auto Templating feature instead. Details about how to use manual configuration are available in the [Manual Prompt Configuration](/posts/prompt_tunins/manual_prompt_tuning) documentation.
+Manual configuration is an advanced use-case. Most users will want to use the Auto Templating feature instead. Details about how to use manual configuration are available in the [Manual Prompt Configuration](/posts/prompt_tuning/manual_prompt_tuning) documentation.


### PR DESCRIPTION
<!--
Thanks for contributing to GraphRAG!

Please do not make *Draft* pull requests, as they still notify anyone watching the repo.

Create a pull request when it is ready for review and feedback.

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

## Description

The link to [Manual Prompt Tuning](https://microsoft.github.io/graphrag/posts/prompt_tuning/manual_prompt_tuning/) in [this page](https://microsoft.github.io/graphrag/posts/prompt_tuning/overview/) has a typo

<img width="500" src="https://github.com/microsoft/graphrag/assets/58854510/231688cf-3fb6-4ac2-b4cc-9b4646938ba3" />

## Checklist
- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes
N/A