### PR TITLE
In windows prompts cannot be chinese refer to pathlib read_text

### DIFF
--- a/graphrag/config/models/claim_extraction_config.py
+++ b/graphrag/config/models/claim_extraction_config.py
@@ -43,7 +43,7 @@ class ClaimExtractionConfig(LLMConfig):
             "type": ExtractClaimsStrategyType.graph_intelligence,
             "llm": self.llm.model_dump(),
             **self.parallelization.model_dump(),
-            "extraction_prompt": (Path(root_dir) / self.prompt).read_text()
+            "extraction_prompt": (Path(root_dir) / self.prompt).read_text(encoding="utf-8")
             if self.prompt
             else None,
             "claim_description": self.description,

--- a/graphrag/config/models/community_reports_config.py
+++ b/graphrag/config/models/community_reports_config.py
@@ -38,7 +38,7 @@ class CommunityReportsConfig(LLMConfig):
             "type": CreateCommunityReportsStrategyType.graph_intelligence,
             "llm": self.llm.model_dump(),
             **self.parallelization.model_dump(),
-            "extraction_prompt": (Path(root_dir) / self.prompt).read_text()
+            "extraction_prompt": (Path(root_dir) / self.prompt).read_text(encoding="utf-8")
             if self.prompt
             else None,
             "max_report_length": self.max_length,

--- a/graphrag/config/models/entity_extraction_config.py
+++ b/graphrag/config/models/entity_extraction_config.py
@@ -38,7 +38,7 @@ class EntityExtractionConfig(LLMConfig):
             "type": ExtractEntityStrategyType.graph_intelligence,
             "llm": self.llm.model_dump(),
             **self.parallelization.model_dump(),
-            "extraction_prompt": (Path(root_dir) / self.prompt).read_text()
+            "extraction_prompt": (Path(root_dir) / self.prompt).read_text(encoding="utf-8")
             if self.prompt
             else None,
             "max_gleanings": self.max_gleanings,

--- a/graphrag/config/models/summarize_descriptions_config.py
+++ b/graphrag/config/models/summarize_descriptions_config.py
@@ -34,7 +34,7 @@ class SummarizeDescriptionsConfig(LLMConfig):
             "type": SummarizeStrategyType.graph_intelligence,
             "llm": self.llm.model_dump(),
             **self.parallelization.model_dump(),
-            "summarize_prompt": (Path(root_dir) / self.prompt).read_text()
+            "summarize_prompt": (Path(root_dir) / self.prompt).read_text(encoding="utf-8")
             if self.prompt
             else None,
             "max_summary_length": self.max_length,


### PR DESCRIPTION

## Description

In windows , prompts cannot be chinese , because  pathlib read_text default to use gbk to read prompts file;

## Proposed Changes

pathlib read_text add encoding=utf-8 params

## Checklist

- [ *] I have tested these changes locally.
- [ *] I have reviewed the code changes.
- [ *] I have updated the documentation (if necessary).
- [ *] I have added appropriate unit tests (if applicable).

