### PR TITLE
[bug fix] Fix config items tokens_per_minute and requests_per_minute doesn't take effect of llm in setting.yaml

### DIFF
--- a/.semversioner/next-release/patch-20240705122136116220.json
+++ b/.semversioner/next-release/patch-20240705122136116220.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "fix tpm and rpm in setting.yaml under llm"
+}

--- a/graphrag/config/create_graphrag_config.py
+++ b/graphrag/config/create_graphrag_config.py
@@ -251,10 +251,10 @@ def create_graphrag_config(
                     or defs.LLM_REQUEST_TIMEOUT,
                     cognitive_services_endpoint=cognitive_services_endpoint,
                     deployment_name=deployment_name,
-                    tokens_per_minute=reader.int(Fragment.tpm)
-                    or defs.LLM_TOKENS_PER_MINUTE,
-                    requests_per_minute=reader.int(Fragment.rpm)
-                    or defs.LLM_REQUESTS_PER_MINUTE,
+                    tokens_per_minute=reader.int("tokens_per_minute", Fragment.tpm)
+                                      or defs.LLM_TOKENS_PER_MINUTE,
+                    requests_per_minute=reader.int("requests_per_minute", Fragment.rpm)
+                                        or defs.LLM_REQUESTS_PER_MINUTE,
                     max_retries=reader.int(Fragment.max_retries)
                     or defs.LLM_MAX_RETRIES,
                     max_retry_wait=reader.float(Fragment.max_retry_wait)


### PR DESCRIPTION
## Description

When setting `tokens_per_minute` and `requests_per_minute` of llm in setting.yaml, it doesn't take effect. This is because config reader only read `tpm` and `rpm` instead of the item in setting.yaml template. It causes lots of llm error.

This PR fix this issue by updating the config item name when reading config in `graphrag/config/create_graphrag_config.py`

## Related Issues

https://github.com/microsoft/graphrag/issues/379

## Proposed Changes

- reading tokens_per_minute instead of tpm to align with setting.yaml
- reading requests_per_minute instead of rpm to align with setting.yaml

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes

[Add any additional notes or context that may be helpful for the reviewer(s).]
