### PR TITLE
Expose http_client for httpx client customization with custom root certificates

### DIFF
--- a/.semversioner/next-release/minor-20240705201514907488.json
+++ b/.semversioner/next-release/minor-20240705201514907488.json
@@ -1,0 +1,4 @@
+{
+  "type": "minor",
+  "description": "Exposed http_client and http_client_async for custom SSL configuration with httpx clients and updated documentation."
+}

--- a/docsite/posts/config/corporate_ssl.md
+++ b/docsite/posts/config/corporate_ssl.md
@@ -52,7 +52,7 @@ To use the custom SSL configuration, follow these steps:
 
 1. **Install Dependencies**: Run `poetry add httpx[http2] pip-system-certs`.
 2. **SSL Configuration**: Use the provided Python script to set up `httpx` clients with custom SSL certificates.
-3. **Integration**: Integrate the configured `httpx` clients into your application, such as with `ChatOpenAI`.
+3. **Integration**: Integrate the configured `httpx` clients into your application, as demonstrated above with the `ChatOpenAI` llm.
 
 ## Additional Notes
 

--- a/docsite/posts/config/corporate_ssl.md
+++ b/docsite/posts/config/corporate_ssl.md
@@ -1,0 +1,65 @@
+# Custom SSL Configuration Mode
+
+---
+title: Custom SSL Configuration Mode
+navtitle: Custom SSL Config
+layout: page
+tags: [post]
+date: 2024-07-05
+---
+
+In certain corporate environments, it is common to have custom root certificates for SSL/TLS communication. This guide explains how to configure `httpx` clients to work with these custom root certificates in GraphRAG.
+
+## Installation
+
+First, you'll need to install the necessary dependencies. Run the following command:
+
+```sh
+poetry add httpx[http2] pip-system-certs
+```
+
+## Configuration
+
+Below is a sample configuration to set up `httpx` clients with custom SSL certificates:
+
+```python
+import httpx
+import ssl
+
+# Create a default SSL context and load the system's default certificates
+context = ssl.create_default_context()
+context.load_default_certs(ssl.Purpose.SERVER_AUTH)  # Load certs for server authentication
+verify = context
+
+# Create an httpx client and pass the SSL certificate context
+httpx_client = httpx.Client(http2=True, verify=verify)
+httpx_client_async = httpx.AsyncClient(http2=True, verify=verify)
+
+# Example of integrating with ChatOpenAI
+llm = ChatOpenAI(
+    ... # other parameters
+    # pass both the synchronous and async clients to the initializer
+    http_client=httpx_client,
+    http_client_async=httpx_client_async,
+)
+
+# Continue remaining code as normal...
+```
+
+## Usage
+
+To use the custom SSL configuration, follow these steps:
+
+1. **Install Dependencies**: Run `poetry add httpx[http2] pip-system-certs`.
+2. **SSL Configuration**: Use the provided Python script to set up `httpx` clients with custom SSL certificates.
+3. **Integration**: Integrate the configured `httpx` clients into your application, such as with `ChatOpenAI`.
+
+## Additional Notes
+
+Using custom SSL configurations is an advanced use-case primarily for secure communication in corporate environments with custom root certificates. Most users will not need to modify these settings.
+
+Refer to the [examples](https://github.com/microsoft/graphrag/blob/main/examples/) directory for more details on running different configurations.
+
+---
+
+This custom configuration ensures secure and reliable communication within corporate environments requiring specific SSL/TLS setups.

--- a/graphrag/query/llm/oai/base.py
+++ b/graphrag/query/llm/oai/base.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 
 from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
+from httpx import Client, AsyncClient
 
 from graphrag.query.llm.base import BaseTextEmbedding
 from graphrag.query.llm.oai.typing import OpenaiApiType
@@ -101,8 +102,8 @@ class OpenAILLMImpl(BaseOpenAILLM):
         max_retries: int = 10,
         request_timeout: float = 180.0,
         reporter: StatusReporter | None = None,
-        http_client: Callable | None = None,
-        http_client_async: Callable | None = None,
+        http_client: Client | None = None,
+        http_client_async: AsyncClient | None = None,
     ):
         self.api_key = api_key
         self.azure_ad_token_provider = azure_ad_token_provider

--- a/graphrag/query/llm/oai/base.py
+++ b/graphrag/query/llm/oai/base.py
@@ -101,6 +101,8 @@ class OpenAILLMImpl(BaseOpenAILLM):
         max_retries: int = 10,
         request_timeout: float = 180.0,
         reporter: StatusReporter | None = None,
+        http_client: Callable | None = None,
+        http_client_async: Callable | None = None,
     ):
         self.api_key = api_key
         self.azure_ad_token_provider = azure_ad_token_provider
@@ -112,6 +114,8 @@ class OpenAILLMImpl(BaseOpenAILLM):
         self.max_retries = max_retries
         self.request_timeout = request_timeout
         self.reporter = reporter or ConsoleStatusReporter()
+        self.http_client = http_client
+        self.http_client_async = http_client_async
 
         try:
             # Create OpenAI sync and async clients
@@ -141,6 +145,7 @@ class OpenAILLMImpl(BaseOpenAILLM):
                 # Retry Configuration
                 timeout=self.request_timeout,
                 max_retries=self.max_retries,
+                http_client=self.http_client,
             )
 
             async_client = AsyncAzureOpenAI(
@@ -154,6 +159,7 @@ class OpenAILLMImpl(BaseOpenAILLM):
                 # Retry Configuration
                 timeout=self.request_timeout,
                 max_retries=self.max_retries,
+                http_client=self.http_client_async,
             )
             self.set_clients(sync_client=sync_client, async_client=async_client)
 
@@ -165,6 +171,7 @@ class OpenAILLMImpl(BaseOpenAILLM):
                 # Retry Configuration
                 timeout=self.request_timeout,
                 max_retries=self.max_retries,
+                http_client=self.http_client,
             )
 
             async_client = AsyncOpenAI(
@@ -174,6 +181,7 @@ class OpenAILLMImpl(BaseOpenAILLM):
                 # Retry Configuration
                 timeout=self.request_timeout,
                 max_retries=self.max_retries,
+                http_client=self.http_client_async,
             )
             self.set_clients(sync_client=sync_client, async_client=async_client)
 

--- a/graphrag/query/llm/oai/chat_openai.py
+++ b/graphrag/query/llm/oai/chat_openai.py
@@ -43,6 +43,8 @@ class ChatOpenAI(BaseLLM, OpenAILLMImpl):
         request_timeout: float = 180.0,
         retry_error_types: tuple[type[BaseException]] = OPENAI_RETRY_ERROR_TYPES,  # type: ignore
         reporter: StatusReporter | None = None,
+        http_client: Callable | None = None,
+        http_client_async: Callable | None = None,
     ):
         OpenAILLMImpl.__init__(
             self=self,
@@ -56,6 +58,8 @@ class ChatOpenAI(BaseLLM, OpenAILLMImpl):
             max_retries=max_retries,
             request_timeout=request_timeout,
             reporter=reporter,
+            http_client=http_client,
+            http_client_async=http_client_async,
         )
         self.model = model
         self.retry_error_types = retry_error_types

--- a/graphrag/query/llm/oai/chat_openai.py
+++ b/graphrag/query/llm/oai/chat_openai.py
@@ -5,6 +5,7 @@
 
 from collections.abc import Callable
 from typing import Any
+from httpx import Client, AsyncClient
 
 from tenacity import (
     AsyncRetrying,
@@ -43,8 +44,8 @@ class ChatOpenAI(BaseLLM, OpenAILLMImpl):
         request_timeout: float = 180.0,
         retry_error_types: tuple[type[BaseException]] = OPENAI_RETRY_ERROR_TYPES,  # type: ignore
         reporter: StatusReporter | None = None,
-        http_client: Callable | None = None,
-        http_client_async: Callable | None = None,
+        http_client: Client | None = None,
+        http_client_async: AsyncClient | None = None,
     ):
         OpenAILLMImpl.__init__(
             self=self,


### PR DESCRIPTION
## Description

Exposed `http_client` to the consumer, to allow httpx client customization in case of execution within a corporate environment with custom root certs.

## Related Issues

N/A

## Proposed Changes

- Exposed `http_client` in the `graphrag.query.llm.oai.chat_openai.ChatOpenAI` module.

### Detailed Changes

- **Added `http_client` and `http_client_async` parameters** to the `__init__` method in `graphrag/query/llm/oai/base.py` and `graphrag/query/llm/oai/chat_openai.py`.
- **Modified the `_create_openai_client` method** in `graphrag/query/llm/oai/base.py` to utilize the `http_client` and `http_client_async` parameters for both synchronous and asynchronous clients.
- **Documentation Update**: Added a new page `docsite/posts/config/corporate_ssl.md` detailing how to configure `httpx` clients with custom SSL certificates.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes

Using custom root certs is a fairly uncommon scenario, but this change is critical to allow secure communication under those conditions.