### PR TITLE
Reduce cost and time to 1/4 than before

### DIFF
--- a/.semversioner/next-release/patch-20240710114442871595.json
+++ b/.semversioner/next-release/patch-20240710114442871595.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "enlarge the chunk size to reduce the cost and time greatly to 1/4"
+}

--- a/graphrag/config/defaults.py
+++ b/graphrag/config/defaults.py
@@ -45,8 +45,8 @@ EMBEDDING_TARGET = TextEmbeddingTarget.required
 
 CACHE_TYPE = CacheType.file
 CACHE_BASE_DIR = "cache"
-CHUNK_SIZE = 300
-CHUNK_OVERLAP = 100
+CHUNK_SIZE = 1024
+CHUNK_OVERLAP = 20
 CHUNK_GROUP_BY_COLUMNS = ["id"]
 CLAIM_DESCRIPTION = (
     "Any claims or facts that could be relevant to information discovery."


### PR DESCRIPTION
## Description

When indexing, it will take a lot of time and cost since we make a lot of entity extraction.
This is original discussion and test result: https://github.com/microsoft/graphrag/discussions/460

## Related Issues

https://github.com/microsoft/graphrag/issues/431
https://github.com/microsoft/graphrag/issues/385

## Proposed Changes

Enlarge the default chunk size to reduce the **cost and time greatly to 1/4** than before and get better answer.
The default chunk size is refer to LlamaIndex.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes

[Add any additional notes or context that may be helpful for the reviewer(s).]
