### PR TITLE
[Bug#546]update key from community_reports to community_report

### DIFF
--- a/graphrag/config/create_graphrag_config.py
+++ b/graphrag/config/create_graphrag_config.py
@@ -439,7 +439,7 @@ def create_graphrag_config(
                 or defs.CLAIM_MAX_GLEANINGS,
             )
 
-        community_report_config = values.get("community_reports") or {}
+        community_report_config = values.get("community_report") or {}
         with (
             reader.envvar_prefix(Section.community_reports),
             reader.use(community_report_config),


### PR DESCRIPTION
<!--
Thanks for contributing to GraphRAG!

Please do not make *Draft* pull requests, as they still notify anyone watching the repo.

Create a pull request when it is ready for review and feedback.

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

## Description

[Provide a brief description of the changes made in this pull request.]

In graphrag.config.create_graphrag_config.py, it refers to a wrong key name for the community report section of settings.yaml, it causes the problem that the community report config was never read into the program.




## Related Issues

bug#546

## Proposed Changes

[List the specific changes made in this pull request.]
file path: graphrag.config.create_graphrag_config.py
line #: 442
community_report_config = values.get("community_reports") or {}
change to:
ommunity_report_config = values.get("community_report") or {}

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes

[Add any additional notes or context that may be helpful for the reviewer(s).]
