### PR TITLE
JSON parsing: always fix all incoming json when using _manual_json

### DIFF
--- a/graphrag/index/utils/__init__.py
+++ b/graphrag/index/utils/__init__.py
@@ -6,7 +6,7 @@
 from .dicts import dict_has_keys_with_types
 from .hashing import gen_md5_hash
 from .is_null import is_null
-from .json import clean_up_json
+from .json import clean_up_json, fix_malformed_json
 from .load_graph import load_graph
 from .string import clean_str
 from .tokens import num_tokens_from_string, string_from_tokens
@@ -16,6 +16,7 @@ from .uuid import gen_uuid
 __all__ = [
     "clean_str",
     "clean_up_json",
+    "fix_malformed_json",
     "dict_has_keys_with_types",
     "gen_md5_hash",
     "gen_uuid",

--- a/graphrag/index/utils/json.py
+++ b/graphrag/index/utils/json.py
@@ -1,7 +1,14 @@
 # Copyright (c) 2024 Microsoft Corporation.
 # Licensed under the MIT License
 
+from json_repair import repair_json
+
 """JSON cleaning and formatting utilities."""
+
+
+def fix_malformed_json(json_str: str) -> str:
+    """Fixup potentially malformed json string using json_repair."""
+    return str(repair_json(json_str=json_str, return_objects=False))
 
 
 def clean_up_json(json_str: str):

--- a/graphrag/llm/openai/_json.py
+++ b/graphrag/llm/openai/_json.py
@@ -1,7 +1,14 @@
 # Copyright (c) 2024 Microsoft Corporation.
 # Licensed under the MIT License
 
+from json_repair import repair_json
+
 """JSON cleaning and formatting utilities."""
+
+
+def fix_malformed_json(json_str: str) -> str:
+    """Fixup potentially malformed json string using json_repair."""
+    return str(repair_json(json_str=json_str, return_objects=False))
 
 
 def clean_up_json(json_str: str) -> str:

--- a/graphrag/llm/openai/openai_chat_llm.py
+++ b/graphrag/llm/openai/openai_chat_llm.py
@@ -16,7 +16,7 @@ from graphrag.llm.types import (
     LLMOutput,
 )
 
-from ._json import clean_up_json
+from ._json import clean_up_json, fix_malformed_json
 from ._prompts import JSON_CHECK_PROMPT
 from .openai_configuration import OpenAIConfiguration
 from .types import OpenAIClientTypes
@@ -120,6 +120,7 @@ class OpenAIChatLLM(BaseLLM[CompletionInput, CompletionOutput]):
         result = await self._invoke(input, **kwargs)
         history = result.history or []
         output = clean_up_json(result.output or "")
+        output = fix_malformed_json(result.output or "")
         try:
             json_output = try_parse_json_object(output)
             return LLMOutput[CompletionOutput](

--- a/graphrag/llm/openai/openai_chat_llm.py
+++ b/graphrag/llm/openai/openai_chat_llm.py
@@ -120,7 +120,7 @@ class OpenAIChatLLM(BaseLLM[CompletionInput, CompletionOutput]):
         result = await self._invoke(input, **kwargs)
         history = result.history or []
         output = clean_up_json(result.output or "")
-        output = fix_malformed_json(result.output or "")
+        output = fix_malformed_json(output)
         try:
             json_output = try_parse_json_object(output)
             return LLMOutput[CompletionOutput](

--- a/graphrag/query/structured_search/global_search/search.py
+++ b/graphrag/query/structured_search/global_search/search.py
@@ -13,7 +13,7 @@ from typing import Any
 import pandas as pd
 import tiktoken
 
-from graphrag.index.utils.json import clean_up_json
+from graphrag.index.utils.json import clean_up_json, fix_malformed_json
 from graphrag.query.context_builder.builders import GlobalContextBuilder
 from graphrag.query.context_builder.conversation_history import (
     ConversationHistory,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1701,6 +1701,17 @@ files = [
 ]
 
 [[package]]
+name = "json-repair"
+version = "0.25.3"
+description = "A package to repair broken json strings"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "json_repair-0.25.3-py3-none-any.whl", hash = "sha256:f00b510dd21b31ebe72581bdb07e66381df2883d6f640c89605e482882c12b17"},
+    {file = "json_repair-0.25.3.tar.gz", hash = "sha256:4ee970581a05b0b258b749eb8bcac21de380edda97c3717a4edfafc519ec21a4"},
+]
+
+[[package]]
 name = "json5"
 version = "0.9.25"
 description = "A Python implementation of the JSON5 data format."
@@ -5110,4 +5121,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "01ee5a94c60b640ad124c27244a21cf97ddbd7effdd7aaf89ff8c896af3a0887"
+content-hash = "42e1d25dc31cb8ee4185d3d68e8f3ea20570e52b58f54cf35071a4c36a629acf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ openai = "^1.35.7"
 nltk = "3.8.1"
 tiktoken = "^0.7.0"
 
+# LLM JSON parsing
+json-repair = "0.25.3"
+
 # Data-Sci
 numba = "0.60.0"
 numpy = "^1.25.2"


### PR DESCRIPTION
## Description

This change set adds non-LLM-based JSON malformity handling as a preliminary step before using the more resource-intensive LLM-based fixup.

### More Details

While running GraphRAG with a local Ollama model, I noticed frequent malformed JSON responses from LLM requests, significantly slowing down the process on an M1 Max MacBook. In a fast, parallel cloud inference system, this issue is manageable, but locally it becomes a bottleneck. After indexing, I found 140 instances of JSON parsing failures.

The `json_repair` library effectively fixed the malformed JSON in my tests. I opted not to delve into the specific parsing failure cases, as they are mainly LLM-related and predicting every edge case is impractical. This library should be robust enough to handle most local LLM faults.

## Related Issues

- https://github.com/microsoft/graphrag/issues/345

## Proposed Changes

- Add `json_repair` as a new Poetry dependency.
  - https://pypi.org/project/json-repair/
- Use `json_repair` for initial JSON repair in `_manual_json`, with a fallback to the LLM.
- Apply JSON repair when graph search JSON parsing fails.

## Checklist

- [x] Tested these changes locally.
- [x] Reviewed the code changes.
- [x] Updated documentation (if necessary).
- [ ] Added appropriate unit tests (if applicable).
