### PR TITLE
[Fix bug] Better for local embedding models

### DIFF
--- a/graphrag/query/llm/oai/embedding.py
+++ b/graphrag/query/llm/oai/embedding.py
@@ -82,7 +82,7 @@ class OpenAIEmbedding(BaseTextEmbedding, OpenAILLMImpl):
         chunk_lens = []
         for chunk in token_chunks:
             try:
-                embedding, chunk_len = self._embed_with_retry(chunk, **kwargs)
+                embedding, chunk_len = self._embed_with_retry(self.token_encoder.decode(chunk), **kwargs)
                 chunk_embeddings.append(embedding)
                 chunk_lens.append(chunk_len)
             # TODO: catch a more specific exception
@@ -109,7 +109,7 @@ class OpenAIEmbedding(BaseTextEmbedding, OpenAILLMImpl):
         chunk_embeddings = []
         chunk_lens = []
         embedding_results = await asyncio.gather(*[
-            self._aembed_with_retry(chunk, **kwargs) for chunk in token_chunks
+            self._aembed_with_retry(self.token_encoder.decode(chunk), **kwargs) for chunk in token_chunks
         ])
         embedding_results = [result for result in embedding_results if result[0]]
         chunk_embeddings = [result[0] for result in embedding_results]


### PR DESCRIPTION
## Description

This pull request adds functionality to decode chunks back to strings, enabling the use of local embedding models that only accept string inputs.

## Related Issues

https://github.com/microsoft/graphrag/issues/451
https://github.com/microsoft/graphrag/issues/528

## Proposed Changes

- Decodes the encoded chunks back to strings.
- Integrates the local embedding models with the decoded strings.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes

These changes ensure compatibility with local embedding models that require string inputs, enhancing the overall functionality and flexibility of the system.