### PR TITLE
fix - in run_local_search(), avoid re-reading create_final_nodes.parquet file

### DIFF
--- a/graphrag/query/cli.py
+++ b/graphrag/query/cli.py
@@ -109,8 +109,7 @@ def run_local_search(
     final_text_units = pd.read_parquet(data_path / "create_final_text_units.parquet")
     final_relationships = pd.read_parquet(
         data_path / "create_final_relationships.parquet"
-    )
-    final_nodes = pd.read_parquet(data_path / "create_final_nodes.parquet")
+    )    
     final_entities = pd.read_parquet(data_path / "create_final_entities.parquet")
     final_covariates_path = data_path / "create_final_covariates.parquet"
     final_covariates = (


### PR DESCRIPTION
## Description

The file `create_final_nodes.parquet` is being read twice in run_local_search function in query component

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).
