### PR TITLE
Clean the string and extract only the JSON part

### DIFF
--- a/graphrag/query/structured_search/global_search/search.py
+++ b/graphrag/query/structured_search/global_search/search.py
@@ -233,8 +233,9 @@ class GlobalSearch(BaseSearch):
         json_match = re.search(r"\{.*\}", search_response, re.DOTALL)
 
         if not json_match:
-            raise ValueError("No JSON object found in search response")
-        
+            msg = "No JSON object found in search response"
+            raise ValueError(msg)
+
         json_str = json_match.group(0)
 
         parsed_elements = json.loads(json_str)["points"]

--- a/graphrag/query/structured_search/global_search/search.py
+++ b/graphrag/query/structured_search/global_search/search.py
@@ -6,6 +6,7 @@
 import asyncio
 import json
 import logging
+import re
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -229,7 +230,14 @@ class GlobalSearch(BaseSearch):
         list[dict[str, Any]]
             A list of key points, each key point is a dictionary with "answer" and "score" keys
         """
-        parsed_elements = json.loads(search_response)["points"]
+        json_match = re.search(r"\{.*\}", search_response, re.DOTALL)
+
+        if not json_match:
+            raise ValueError("No JSON object found in search response")
+        
+        json_str = json_match.group(0)
+
+        parsed_elements = json.loads(json_str)["points"]
         return [
             {
                 "answer": element["description"],


### PR DESCRIPTION
<!--
Thanks for contributing to GraphRAG!

Please do not make *Draft* pull requests, as they still notify anyone watching the repo.

Create a pull request when it is ready for review and feedback.

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

## Description

This JSON parsing error in the global search is mainly because, for some open-source LLMs, the response is not strictly JSON format. For example, when asking about the main theme of the story, Llama3 would give an answer like this:

```
Here is a response consisting of a list of key points that summarizes the top themes in the provided data:

{"points": [    {"description": "The theme of community and social dynamics is prominent, with the Men's Elations and Sorrows community revolving around men experiencing elations and sorrows. [Data: Reports (1)]", "score": 80},    {"description": "The potential for threat or conflict is a significant theme, with Harmony Assembly's march at Verdant Oasis Plaza being a potential source of threat. [Data: Reports (6), Relationships (38, 43)]", "score": 70}}

Note that these scores are subjective and based on my interpretation of the data provided.
```
This is not a valid JSON format due to the additional content before and after the expected JSON.

## Related Issues

[[Issue]: All workflows completed successfully，but graphrag failed to answer any question given the provided data](https://github.com/microsoft/graphrag/issues/575)

## Proposed Changes

* Added a regular expression to extract JSON content from the search response string

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes
