### PR TITLE
Update community_reports_extractor.py to accept integer rating

### DIFF
--- a/graphrag/index/graph/extractors/community_reports/community_reports_extractor.py
+++ b/graphrag/index/graph/extractors/community_reports/community_reports_extractor.py
@@ -66,7 +66,7 @@ class CommunityReportsExtractor:
                             ("title", str),
                             ("summary", str),
                             ("findings", list),
-                            ("rating", float),
+                            ("rating", float | int),
                             ("rating_explanation", str),
                         ],
                     ),


### PR DESCRIPTION
## Description

There were "Failed to generate valid JSON output" errors when generating community reports, it turns out it could be because some models (I'm using Ollama) output integer ratings for the results, but the code validating the result requires rating to be a float.

## Proposed Changes

Update code community_reports_extractor.py to let the `is_response_valid` lambda to accept `float | int` instead of just `float`

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).
