### PR TITLE
Use clean_up_json to process strings when executing try_parse_json_ob…

### DIFF
--- a/graphrag/llm/openai/utils.py
+++ b/graphrag/llm/openai/utils.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from typing import Any
 
 import tiktoken
+from graphrag.llm.openai._json import clean_up_json
 from openai import (
     APIConnectionError,
     InternalServerError,
@@ -90,7 +91,7 @@ def get_completion_llm_args(
 def try_parse_json_object(input: str) -> dict:
     """Generate JSON-string output using best-attempt prompting & parsing techniques."""
     try:
-        result = json.loads(input)
+        result = json.loads(clean_up_json(input))
     except json.JSONDecodeError:
         log.exception("error loading json, json=%s", input)
         raise


### PR DESCRIPTION
[Reference any related issues or tasks that this pull request addresses.]

## Proposed Changes

Solved the case where try_parse_json_object handles json strings in markdown or other formats that can be solved by letting the application return normally.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes

[Add any additional notes or context that may be helpful for the reviewer(s).]

