### PR TITLE
[bug]Fix bad tune prompt for the LLM not support JSON.

### DIFF
--- a/.semversioner/next-release/patch-20240723033252338748.json
+++ b/.semversioner/next-release/patch-20240723033252338748.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "fix bad tune prompt"
+}

--- a/graphrag/prompt_tune/prompt/entity_relationship.py
+++ b/graphrag/prompt_tune/prompt/entity_relationship.py
@@ -12,8 +12,8 @@ Given a text document that is potentially relevant to this activity and a list o
 - entity_name: Name of the entity, capitalized
 - entity_type: One of the following types: [{entity_types}]
 - entity_description: Comprehensive description of the entity's attributes and activities
-Format each entity, include the parenthesis at the beginning and end, as ("entity"{{tuple_delimiter}}<entity_name>{{tuple_delimiter}}<entity_type>{{tuple_delimiter}}<entity_description>)
-for example: ("entity"{{tuple_delimiter}}"Microsoft"{{tuple_delimiter}}"organization"{{tuple_delimiter}}"Microsoft is a technology company")
+Format each entity, include the parenthesis at the beginning and end, as ("entity"{{tuple_delimiter}}<entity_name>{{tuple_delimiter}}<entity_type>{{tuple_delimiter}}<entity_description>){{record_delimiter}}
+for example: ("entity"{{tuple_delimiter}}"Microsoft"{{tuple_delimiter}}"organization"{{tuple_delimiter}}"Microsoft is a technology company"){{record_delimiter}}
 
 2. From the entities identified in step 1, identify all pairs of (source_entity, target_entity) that are *clearly related* to each other.
 For each pair of related entities, extract the following information:
@@ -21,12 +21,14 @@ For each pair of related entities, extract the following information:
 - target_entity: name of the target entity, as identified in step 1
 - relationship_description: explanation as to why you think the source entity and the target entity are related to each other
 - relationship_strength: an integer score between 1 to 10, indicating strength of the relationship between the source entity and target entity
-Format each relationship, include the parenthesis at the beginning and end, as ("relationship"{{tuple_delimiter}}<source_entity>{{tuple_delimiter}}<target_entity>{{tuple_delimiter}}<relationship_description>{{tuple_delimiter}}<relationship_strength>)
-for example: ("relationship"{{tuple_delimiter}}"company A"{{tuple_delimiter}}"person A"{{tuple_delimiter}}"company A is currently owned by person A"{{tuple_delimiter}}8)
+Format each relationship, include the parenthesis at the beginning and end, as ("relationship"{{tuple_delimiter}}<source_entity>{{tuple_delimiter}}<target_entity>{{tuple_delimiter}}<relationship_description>{{tuple_delimiter}}<relationship_strength>){{record_delimiter}}
+for example: ("relationship"{{tuple_delimiter}}"company A"{{tuple_delimiter}}"person A"{{tuple_delimiter}}"company A is currently owned by person A"{{tuple_delimiter}}8){{record_delimiter}}
 
-3. Return output in {language} as a single list of all the entities and relationships identified in steps 1 and 2. Use **{{record_delimiter}}** as the list delimiter. If you have to translate, just translate the descriptions, nothing else!
+3. Use **{{record_delimiter}}** as the list delimiter.
 
-4. When finished, output {{completion_delimiter}}.
+4. Return output in {language} as a single list of all the entities and relationships identified in steps 1 and 2. If you have to translate, just translate the descriptions, nothing else!
+
+5. When finished, output {{completion_delimiter}}.
 
 -Real Data-
 ######################
@@ -81,7 +83,7 @@ Next, report all relationships among the identified entities.
 - entity_name: Name of the entity, capitalized
 - entity_type: Suggest several labels or categories for the entity. The categories should not be specific, but should be as general as possible.
 - entity_description: Comprehensive description of the entity's attributes and activities
-Format each entity as ("entity"{{tuple_delimiter}}<entity_name>{{tuple_delimiter}}<entity_type>{{tuple_delimiter}}<entity_description>
+Format each entity as ("entity"{{tuple_delimiter}}<entity_name>{{tuple_delimiter}}<entity_type>{{tuple_delimiter}}<entity_description>){{record_delimiter}}
 
 2. From the entities identified in step 1, identify all pairs of (source_entity, target_entity) that are *clearly related* to each other.
 For each pair of related entities, extract the following information:
@@ -89,11 +91,13 @@ For each pair of related entities, extract the following information:
 - target_entity: name of the target entity, as identified in step 1
 - relationship_description: explanation as to why you think the source entity and the target entity are related to each other
 - relationship_strength: a numeric score indicating strength of the relationship between the source entity and target entity
- Format each relationship as ("relationship"{{tuple_delimiter}}<source_entity>{{tuple_delimiter}}<target_entity>{{tuple_delimiter}}<relationship_description>{{tuple_delimiter}}<relationship_strength>)
+ Format each relationship as ("relationship"{{tuple_delimiter}}<source_entity>{{tuple_delimiter}}<target_entity>{{tuple_delimiter}}<relationship_description>{{tuple_delimiter}}<relationship_strength>){{record_delimiter}}
 
-3. Return output in {language} as a single list of all the entities and relationships identified in steps 1 and 2. Use **{{record_delimiter}}** as the list delimiter. If you have to translate, just translate the descriptions, nothing else!
+3. Use **{{record_delimiter}}** as the list delimiter.
 
-4. When finished, output {{completion_delimiter}}
+4. Return output in {language} as a single list of all the entities and relationships identified in steps 1 and 2. If you have to translate, just translate the descriptions, nothing else!
+
+5. When finished, output {{completion_delimiter}}
 
 ######################
 -Examples-

--- a/graphrag/prompt_tune/template/entity_extraction.py
+++ b/graphrag/prompt_tune/template/entity_extraction.py
@@ -12,7 +12,7 @@ Given a text document that is potentially relevant to this activity and a list o
 - entity_name: Name of the entity, capitalized
 - entity_type: One of the following types: [{entity_types}]
 - entity_description: Comprehensive description of the entity's attributes and activities
-Format each entity as ("entity"{{tuple_delimiter}}<entity_name>{{tuple_delimiter}}<entity_type>{{tuple_delimiter}}<entity_description>
+Format each entity as ("entity"{{tuple_delimiter}}<entity_name>{{tuple_delimiter}}<entity_type>{{tuple_delimiter}}<entity_description>){{record_delimiter}}
 
 2. From the entities identified in step 1, identify all pairs of (source_entity, target_entity) that are *clearly related* to each other.
 For each pair of related entities, extract the following information:
@@ -21,11 +21,13 @@ For each pair of related entities, extract the following information:
 - relationship_description: explanation as to why you think the source entity and the target entity are related to each other
 - relationship_strength: an integer score between 1 to 10, indicating strength of the relationship between the source entity and target entity
 
-Format each relationship as ("relationship"{{tuple_delimiter}}<source_entity>{{tuple_delimiter}}<target_entity>{{tuple_delimiter}}<relationship_description>{{tuple_delimiter}}<relationship_strength>)
+Format each relationship as ("relationship"{{tuple_delimiter}}<source_entity>{{tuple_delimiter}}<target_entity>{{tuple_delimiter}}<relationship_description>{{tuple_delimiter}}<relationship_strength>){{record_delimiter}}
 
-3. Return output in {language} as a single list of all the entities and relationships identified in steps 1 and 2. Use **{{record_delimiter}}** as the list delimiter. If you have to translate, just translate the descriptions, nothing else!
+3, Use **{{record_delimiter}}** as the list delimiter.
 
-4. When finished, output {{completion_delimiter}}
+4. Return output in {language} as a single list of all the entities and relationships identified in steps 1 and 2. If you have to translate, just translate the descriptions, nothing else!
+
+5. When finished, output {{completion_delimiter}}
 
 -Examples-
 ######################
@@ -110,7 +112,7 @@ Next, report all relationships among the identified entities.
 - entity_name: Name of the entity, capitalized
 - entity_type: Suggest several labels or categories for the entity. The categories should not be specific, but should be as general as possible.
 - entity_description: Comprehensive description of the entity's attributes and activities
-Format each entity as ("entity"{{tuple_delimiter}}<entity_name>{{tuple_delimiter}}<entity_type>{{tuple_delimiter}}<entity_description>
+Format each entity as ("entity"{{tuple_delimiter}}<entity_name>{{tuple_delimiter}}<entity_type>{{tuple_delimiter}}<entity_description>){{record_delimiter}}
 
 2. From the entities identified in step 1, identify all pairs of (source_entity, target_entity) that are *clearly related* to each other.
 For each pair of related entities, extract the following information:
@@ -118,11 +120,13 @@ For each pair of related entities, extract the following information:
 - target_entity: name of the target entity, as identified in step 1
 - relationship_description: explanation as to why you think the source entity and the target entity are related to each other
 - relationship_strength: a numeric score indicating strength of the relationship between the source entity and target entity
- Format each relationship as ("relationship"{{tuple_delimiter}}<source_entity>{{tuple_delimiter}}<target_entity>{{tuple_delimiter}}<relationship_description>{{tuple_delimiter}}<relationship_strength>)
+ Format each relationship as ("relationship"{{tuple_delimiter}}<source_entity>{{tuple_delimiter}}<target_entity>{{tuple_delimiter}}<relationship_description>{{tuple_delimiter}}<relationship_strength>){{record_delimiter}}
 
-3. Return output in {language} as a single list of all the entities and relationships identified in steps 1 and 2. Use **{{record_delimiter}}** as the list delimiter. If you have to translate, just translate the descriptions, nothing else!
+3. Use **{{record_delimiter}}** as the list delimiter.
 
-4. When finished, output {{completion_delimiter}}
+4. Return output in {language} as a single list of all the entities and relationships identified in steps 1 and 2. If you have to translate, just translate the descriptions, nothing else!
+
+5. When finished, output {{completion_delimiter}}
 
 -Examples-
 ######################


### PR DESCRIPTION
## Description

Prompt-Tune is too bad to generate a valid entity-extraction.txt when using OSS model which doesn't support json model.

The `{record_delimiter}` is very import, but graphrag didn't highlight that in the prompt and even the example is wrong, which cause lots of generated entity-extraction.txt prompt is bad, it is hard to use.

## Related Issues

It will raise EmptyNetworkError when using the prompt generated  by prompt-tune.

## Proposed Changes
1. Separate the request about `Use **{{record_delimiter}}** as the list delimiter.` into 1 single item to highlight the request.
2. Add {{record_delimiter}} to the tail of each item of list in the example format.
- graphrag/prompt_tune/prompt/entity_relationship.py
- graphrag/prompt_tune/template/entity_extraction.py

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes

[Add any additional notes or context that may be helpful for the reviewer(s).]
