### PR TITLE
Fix an possible json parsing error in graphrag.llm.openai.utils.py

### DIFF
--- a/graphrag/llm/openai/openai_chat_llm.py
+++ b/graphrag/llm/openai/openai_chat_llm.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License
 
 """The Chat-based language model."""
-
 import logging
 from json import JSONDecodeError
 
@@ -15,7 +14,6 @@ from graphrag.llm.types import (
     LLMInput,
     LLMOutput,
 )
-
 from ._json import clean_up_json
 from ._prompts import JSON_CHECK_PROMPT
 from .openai_configuration import OpenAIConfiguration
@@ -42,32 +40,34 @@ class OpenAIChatLLM(BaseLLM[CompletionInput, CompletionOutput]):
         self.configuration = configuration
 
     async def _execute_llm(
-        self, input: CompletionInput, **kwargs: Unpack[LLMInput]
+            self, input: CompletionInput, **kwargs: Unpack[LLMInput]
     ) -> CompletionOutput | None:
         args = get_completion_llm_args(
             kwargs.get("model_parameters"), self.configuration
         )
-        history = kwargs.get("history") or []
+        history = []
+
         messages = [
             *history,
             {"role": "user", "content": input},
         ]
-        completion = await self.client.chat.completions.create(
-            messages=messages, **args
-        )
+        # completion = await self.client.chat.completions.create(
+        #     messages=messages, **args
+        # )
+        completion = await self.client.chat.completions.create(messages=messages, **args)
         return completion.choices[0].message.content
 
     async def _invoke_json(
-        self,
-        input: CompletionInput,
-        **kwargs: Unpack[LLMInput],
+            self,
+            input: CompletionInput,
+            **kwargs: Unpack[LLMInput],
     ) -> LLMOutput[CompletionOutput]:
         """Generate JSON output."""
         name = kwargs.get("name") or "unknown"
         is_response_valid = kwargs.get("is_response_valid") or (lambda _x: True)
 
         async def generate(
-            attempt: int | None = None,
+                attempt: int | None = None,
         ) -> LLMOutput[CompletionOutput]:
             call_name = name if attempt is None else f"{name}@{attempt}"
             return (
@@ -90,7 +90,7 @@ class OpenAIChatLLM(BaseLLM[CompletionInput, CompletionOutput]):
         raise RuntimeError(FAILED_TO_CREATE_JSON_ERROR)
 
     async def _native_json(
-        self, input: CompletionInput, **kwargs: Unpack[LLMInput]
+            self, input: CompletionInput, **kwargs: Unpack[LLMInput]
     ) -> LLMOutput[CompletionOutput]:
         """Generate JSON output using a model's native JSON-output support."""
         result = await self._invoke(
@@ -114,7 +114,7 @@ class OpenAIChatLLM(BaseLLM[CompletionInput, CompletionOutput]):
         )
 
     async def _manual_json(
-        self, input: CompletionInput, **kwargs: Unpack[LLMInput]
+            self, input: CompletionInput, **kwargs: Unpack[LLMInput]
     ) -> LLMOutput[CompletionOutput]:
         # Otherwise, clean up the output and try to parse it as json
         result = await self._invoke(input, **kwargs)
@@ -139,7 +139,7 @@ class OpenAIChatLLM(BaseLLM[CompletionInput, CompletionOutput]):
             )
 
     async def _try_clean_json_with_llm(
-        self, output: str, **kwargs: Unpack[LLMInput]
+            self, output: str, **kwargs: Unpack[LLMInput]
     ) -> LLMOutput[CompletionOutput]:
         name = kwargs.get("name") or "unknown"
         return await self._invoke(

--- a/graphrag/llm/openai/utils.py
+++ b/graphrag/llm/openai/utils.py
@@ -15,6 +15,7 @@ from openai import (
     RateLimitError,
 )
 
+from ._json import clean_up_json
 from .openai_configuration import OpenAIConfiguration
 
 DEFAULT_ENCODING = "cl100k_base"
@@ -90,6 +91,7 @@ def get_completion_llm_args(
 def try_parse_json_object(input: str) -> dict:
     """Generate JSON-string output using best-attempt prompting & parsing techniques."""
     try:
+        input = clean_up_json(input)
         result = json.loads(input)
     except json.JSONDecodeError:
         log.exception("error loading json, json=%s", input)


### PR DESCRIPTION
<!--
Thanks for contributing to GraphRAG!

Please do not make *Draft* pull requests, as they still notify anyone watching the repo.

Create a pull request when it is ready for review and feedback.

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

## Description

Some open-source LLM may return something like '''JSON''', they were elegantly processed with the function `clean_up_json` but this function was not used in some places which caused some problems.

## Related Issues



## Proposed Changes
<img width="936" alt="image" src="https://github.com/user-attachments/assets/cea9f944-1169-49f7-ac48-7fe0d24aadb1">


## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes
Tested on qwen2-7b-instruct. Another possible problem is `top_p` in the config file, some llms(qwen-7b for example) only support (0,1) instead of [0,1].
