### PR TITLE
Add user prompt to history-tracking LLM

### DIFF
--- a/.semversioner/next-release/patch-20240725211609305134.json
+++ b/.semversioner/next-release/patch-20240725211609305134.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "add user prompt to history-tracking llm"
+}

--- a/examples/various_levels_of_configs/workflows_and_inputs_with_custom_handlers.py
+++ b/examples/various_levels_of_configs/workflows_and_inputs_with_custom_handlers.py
@@ -90,9 +90,9 @@ class ExampleCache(InMemoryCache):
         print(f"ExampleCache.get {key}")
         return await super().get(key)
 
-    async def set(self, key: str, value: Any, debug_data: dict | None = None) -> None:
+    async def set(self, key: str, data: dict[str, Any]) -> None:
         print(f"ExampleCache.set {key}")
-        return await super().set(key, value, debug_data)
+        return await super().set(key, data)
 
     async def has(self, key: str) -> bool:
         print(f"ExampleCache.has {key}")

--- a/graphrag/config/create_graphrag_config.py
+++ b/graphrag/config/create_graphrag_config.py
@@ -408,6 +408,13 @@ def create_graphrag_config(
             reader.envvar_prefix(Section.entity_extraction),
             reader.use(entity_extraction_config),
         ):
+            max_gleanings = reader.int(Fragment.max_gleanings)
+            max_gleanings = (
+                max_gleanings
+                if max_gleanings is not None
+                else defs.ENTITY_EXTRACTION_MAX_GLEANINGS
+            )
+
             entity_extraction_model = EntityExtractionConfig(
                 llm=hydrate_llm_params(entity_extraction_config, llm_model),
                 parallelization=hydrate_parallelization_params(
@@ -416,8 +423,7 @@ def create_graphrag_config(
                 async_mode=hydrate_async_type(entity_extraction_config, async_mode),
                 entity_types=reader.list("entity_types")
                 or defs.ENTITY_EXTRACTION_ENTITY_TYPES,
-                max_gleanings=reader.int(Fragment.max_gleanings)
-                or defs.ENTITY_EXTRACTION_MAX_GLEANINGS,
+                max_gleanings=max_gleanings,
                 prompt=reader.str("prompt", Fragment.prompt_file),
             )
 
@@ -426,6 +432,10 @@ def create_graphrag_config(
             reader.envvar_prefix(Section.claim_extraction),
             reader.use(claim_extraction_config),
         ):
+            max_gleanings = reader.int(Fragment.max_gleanings)
+            max_gleanings = (
+                max_gleanings if max_gleanings is not None else defs.CLAIM_MAX_GLEANINGS
+            )
             claim_extraction_model = ClaimExtractionConfig(
                 enabled=reader.bool(Fragment.enabled) or defs.CLAIM_EXTRACTION_ENABLED,
                 llm=hydrate_llm_params(claim_extraction_config, llm_model),
@@ -435,8 +445,7 @@ def create_graphrag_config(
                 async_mode=hydrate_async_type(claim_extraction_config, async_mode),
                 description=reader.str("description") or defs.CLAIM_DESCRIPTION,
                 prompt=reader.str("prompt", Fragment.prompt_file),
-                max_gleanings=reader.int(Fragment.max_gleanings)
-                or defs.CLAIM_MAX_GLEANINGS,
+                max_gleanings=max_gleanings,
             )
 
         community_report_config = values.get("community_reports") or {}

--- a/graphrag/index/cache/json_pipeline_cache.py
+++ b/graphrag/index/cache/json_pipeline_cache.py
@@ -39,11 +39,8 @@ class JsonPipelineCache(PipelineCache):
 
         return None
 
-    async def set(self, key: str, value: Any, debug_data: dict | None = None) -> None:
+    async def set(self, key: str, data: dict[str, Any]) -> None:
         """Set method definition."""
-        if value is None:
-            return
-        data = {"result": value, **(debug_data or {})}
         await self._storage.set(key, json.dumps(data), encoding=self._encoding)
 
     async def has(self, key: str) -> bool:

--- a/graphrag/index/cache/json_pipeline_cache.py
+++ b/graphrag/index/cache/json_pipeline_cache.py
@@ -22,7 +22,7 @@ class JsonPipelineCache(PipelineCache):
         self._storage = storage
         self._encoding = encoding
 
-    async def get(self, key: str) -> str | None:
+    async def get(self, key: str) -> dict[str, Any] | None:
         """Get method definition."""
         if await self.has(key):
             try:
@@ -35,7 +35,7 @@ class JsonPipelineCache(PipelineCache):
                 await self._storage.delete(key)
                 return None
             else:
-                return data.get("result")
+                return data
 
         return None
 

--- a/graphrag/index/cache/memory_pipeline_cache.py
+++ b/graphrag/index/cache/memory_pipeline_cache.py
@@ -33,7 +33,7 @@ class InMemoryCache(PipelineCache):
         key = self._create_cache_key(key)
         return self._cache.get(key)
 
-    async def set(self, key: str, value: Any, debug_data: dict | None = None) -> None:
+    async def set(self, key: str, data: dict[str, Any]) -> None:
         """Set the value for the given key.
 
         Args:
@@ -41,7 +41,7 @@ class InMemoryCache(PipelineCache):
             - value - The value to set.
         """
         key = self._create_cache_key(key)
-        self._cache[key] = value
+        self._cache[key] = data
 
     async def has(self, key: str) -> bool:
         """Return True if the given key exists in the storage.

--- a/graphrag/index/cache/noop_pipeline_cache.py
+++ b/graphrag/index/cache/noop_pipeline_cache.py
@@ -24,9 +24,7 @@ class NoopPipelineCache(PipelineCache):
         """
         return None
 
-    async def set(
-        self, key: str, value: str | bytes | None, debug_data: dict | None = None
-    ) -> None:
+    async def set(self, key: str, data: dict[str, Any]) -> None:
         """Set the value for the given key.
 
         Args:

--- a/graphrag/index/cache/pipeline_cache.py
+++ b/graphrag/index/cache/pipeline_cache.py
@@ -26,7 +26,7 @@ class PipelineCache(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    async def set(self, key: str, value: Any, debug_data: dict | None = None) -> None:
+    async def set(self, key: str, data: dict[str, Any]) -> None:
         """Set the value for the given key.
 
         Args:

--- a/graphrag/index/graph/extractors/claims/claim_extractor.py
+++ b/graphrag/index/graph/extractors/claims/claim_extractor.py
@@ -177,12 +177,12 @@ class ClaimExtractor:
 
         # Repeat to ensure we maximize entity count
         for i in range(self._max_gleanings):
-            glean_response = await self._llm(
+            response = await self._llm(
                 CONTINUE_PROMPT,
                 name=f"extract-continuation-{i}",
                 history=response.history or [],
             )
-            extension = glean_response.output or ""
+            extension = response.output or ""
             claims += record_delimiter + extension.strip().removesuffix(
                 completion_delimiter
             )
@@ -191,13 +191,13 @@ class ClaimExtractor:
             if i >= self._max_gleanings - 1:
                 break
 
-            continue_response = await self._llm(
+            response = await self._llm(
                 LOOP_PROMPT,
                 name=f"extract-loopcheck-{i}",
-                history=glean_response.history or [],
+                history=response.history or [],
                 model_parameters=self._loop_args,
             )
-            if continue_response.output != "YES":
+            if response.output != "YES":
                 break
 
         result = self._parse_claim_tuples(results, prompt_args)

--- a/graphrag/llm/base/_create_cache_key.py
+++ b/graphrag/llm/base/_create_cache_key.py
@@ -4,6 +4,7 @@
 """Cache key generation utils."""
 
 import hashlib
+import json
 
 
 def _llm_string(params: dict) -> str:
@@ -19,7 +20,7 @@ def _hash(_input: str) -> str:
     return hashlib.md5(_input.encode()).hexdigest()  # noqa S324
 
 
-def create_hash_key(operation: str, prompt: str, parameters: dict) -> str:
+def create_hash_key(operation: str, prompt: str, parameters: dict, history: dict) -> str:
     """Compute cache key from prompt and associated model and settings.
 
     Args:
@@ -31,4 +32,6 @@ def create_hash_key(operation: str, prompt: str, parameters: dict) -> str:
         str: The cache key.
     """
     llm_string = _llm_string(parameters)
-    return f"{operation}-{_hash(prompt + llm_string)}"
+    history_string = _hash(json.dumps(history)) if history else None
+    hash = _hash(prompt + llm_string + history_string) if history_string else _hash(prompt + llm_string)
+    return f"{operation}-{hash}"

--- a/graphrag/llm/base/_create_cache_key.py
+++ b/graphrag/llm/base/_create_cache_key.py
@@ -21,7 +21,7 @@ def _hash(_input: str) -> str:
 
 
 def create_hash_key(
-    operation: str, prompt: str, parameters: dict, history: dict
+    operation: str, prompt: str, parameters: dict, history: list[dict] | None
 ) -> str:
     """Compute cache key from prompt and associated model and settings.
 

--- a/graphrag/llm/base/_create_cache_key.py
+++ b/graphrag/llm/base/_create_cache_key.py
@@ -20,7 +20,9 @@ def _hash(_input: str) -> str:
     return hashlib.md5(_input.encode()).hexdigest()  # noqa S324
 
 
-def create_hash_key(operation: str, prompt: str, parameters: dict, history: dict) -> str:
+def create_hash_key(
+    operation: str, prompt: str, parameters: dict, history: dict
+) -> str:
     """Compute cache key from prompt and associated model and settings.
 
     Args:
@@ -33,5 +35,9 @@ def create_hash_key(operation: str, prompt: str, parameters: dict, history: dict
     """
     llm_string = _llm_string(parameters)
     history_string = _hash(json.dumps(history)) if history else None
-    hash = _hash(prompt + llm_string + history_string) if history_string else _hash(prompt + llm_string)
-    return f"{operation}-{hash}"
+    hash_string = (
+        _hash(prompt + llm_string + history_string)
+        if history_string
+        else _hash(prompt + llm_string)
+    )
+    return f"{operation}-{hash_string}"

--- a/graphrag/llm/base/caching_llm.py
+++ b/graphrag/llm/base/caching_llm.py
@@ -29,7 +29,7 @@ class CachingLLM(LLM[TIn, TOut], Generic[TIn, TOut]):
     _cache: LLMCache
     _delegate: LLM[TIn, TOut]
     _operation: str
-    _llm_paramaters: dict
+    _llm_parameters: dict
     _on_cache_hit: OnCacheActionFn
     _on_cache_miss: OnCacheActionFn
 
@@ -41,7 +41,7 @@ class CachingLLM(LLM[TIn, TOut], Generic[TIn, TOut]):
         cache: LLMCache,
     ):
         self._delegate = delegate
-        self._llm_paramaters = llm_parameters
+        self._llm_parameters = llm_parameters
         self._cache = cache
         self._operation = operation
         self._on_cache_hit = _noop_cache_fn
@@ -90,7 +90,10 @@ class CachingLLM(LLM[TIn, TOut], Generic[TIn, TOut]):
         """Execute the LLM."""
         # Check for an Existing cache item
         name = kwargs.get("name")
-        llm_args = {**self._llm_paramaters, **(kwargs.get("model_parameters") or {})}
+        history = kwargs.get("history") or None
+        llm_args = {**self._llm_parameters, **(kwargs.get("model_parameters") or {})}
+        if history:
+            llm_args["history"] = history
         cache_key = self._cache_key(input, name, llm_args)
         cached_result = await self._cache_read(cache_key)
         if cached_result:

--- a/graphrag/llm/base/caching_llm.py
+++ b/graphrag/llm/base/caching_llm.py
@@ -71,7 +71,12 @@ class CachingLLM(LLM[TIn, TOut], Generic[TIn, TOut]):
         return await self._cache.get(key)
 
     async def _cache_write(
-        self, key: str, input: TIn, result: TOut | None, args: dict
+        self,
+        key: str,
+        input: TIn,
+        result: TOut | None,
+        args: dict,
+        history: list[dict] | None,
     ) -> None:
         """Write a value to the cache."""
         if result:
@@ -81,6 +86,7 @@ class CachingLLM(LLM[TIn, TOut], Generic[TIn, TOut]):
                 {
                     "input": input,
                     "parameters": args,
+                    "history": history,
                 },
             )
 
@@ -105,6 +111,7 @@ class CachingLLM(LLM[TIn, TOut], Generic[TIn, TOut]):
 
         # Compute the new result
         result = await self._delegate(input, **kwargs)
+
         # Cache the new result
-        await self._cache_write(cache_key, input, result.output, llm_args)
+        await self._cache_write(cache_key, input, result.output, llm_args, history)
         return result

--- a/graphrag/llm/base/caching_llm.py
+++ b/graphrag/llm/base/caching_llm.py
@@ -55,7 +55,9 @@ class CachingLLM(LLM[TIn, TOut], Generic[TIn, TOut]):
         """Set the function to call when a cache miss occurs."""
         self._on_cache_miss = fn or _noop_cache_fn
 
-    def _cache_key(self, input: TIn, name: str | None, args: dict, history: dict | None) -> str:
+    def _cache_key(
+        self, input: TIn, name: str | None, args: dict, history: dict | None
+    ) -> str:
         json_input = json.dumps(input)
         tag = (
             f"{name}-{self._operation}-v{_cache_strategy_version}"

--- a/graphrag/llm/base/caching_llm.py
+++ b/graphrag/llm/base/caching_llm.py
@@ -56,7 +56,7 @@ class CachingLLM(LLM[TIn, TOut], Generic[TIn, TOut]):
         self._on_cache_miss = fn or _noop_cache_fn
 
     def _cache_key(
-        self, input: TIn, name: str | None, args: dict, history: dict | None
+        self, input: TIn, name: str | None, args: dict, history: list[dict] | None
     ) -> str:
         json_input = json.dumps(input)
         tag = (

--- a/graphrag/llm/base/caching_llm.py
+++ b/graphrag/llm/base/caching_llm.py
@@ -102,10 +102,13 @@ class CachingLLM(LLM[TIn, TOut], Generic[TIn, TOut]):
         llm_args = {**self._llm_parameters, **(kwargs.get("model_parameters") or {})}
         cache_key = self._cache_key(input, name, llm_args, history_in)
         cached_result = await self._cache_read(cache_key)
-        
+
         if cached_result:
             self._on_cache_hit(cache_key, name)
-            return LLMOutput(output=cached_result["result"], history=cached_result.get("history") or [])
+            return LLMOutput(
+                output=cached_result["result"],
+                history=cached_result.get("history") or [],
+            )
 
         # Report the Cache Miss
         self._on_cache_miss(cache_key, name)

--- a/graphrag/llm/openai/factories.py
+++ b/graphrag/llm/openai/factories.py
@@ -49,11 +49,11 @@ def create_openai_chat_llm(
     operation = "chat"
     result = OpenAIChatLLM(client, config)
     result.on_error(on_error)
+    result = OpenAIHistoryTrackingLLM(result)
     if limiter is not None or semaphore is not None:
         result = _rate_limited(result, config, operation, limiter, semaphore, on_invoke)
     if cache is not None:
         result = _cached(result, config, operation, cache, on_cache_hit, on_cache_miss)
-    result = OpenAIHistoryTrackingLLM(result)
     result = OpenAITokenReplacingLLM(result)
     return JsonParsingLLM(result)
 

--- a/graphrag/llm/openai/openai_history_tracking_llm.py
+++ b/graphrag/llm/openai/openai_history_tracking_llm.py
@@ -35,8 +35,8 @@ class OpenAIHistoryTrackingLLM(LLM[CompletionInput, CompletionOutput]):
             output=output.output,
             json=output.json,
             history=[
-                *history, 
-                {"role": "user", "content": input.prompt},
-                {"role": "system", "content": output.output}
+                *history,
+                {"role": "user", "content": input},
+                {"role": "system", "content": output.output},
             ],
         )

--- a/graphrag/llm/openai/openai_history_tracking_llm.py
+++ b/graphrag/llm/openai/openai_history_tracking_llm.py
@@ -34,5 +34,9 @@ class OpenAIHistoryTrackingLLM(LLM[CompletionInput, CompletionOutput]):
         return LLMOutput(
             output=output.output,
             json=output.json,
-            history=[*history, {"role": "system", "content": output.output}],
+            history=[
+                *history, 
+                {"role": "user", "content": input.prompt},
+                {"role": "system", "content": output.output}
+            ],
         )

--- a/graphrag/llm/types/llm_cache.py
+++ b/graphrag/llm/types/llm_cache.py
@@ -13,10 +13,10 @@ class LLMCache(Protocol):
         """Check if the cache has a value."""
         ...
 
-    async def get(self, key: str) -> Any | None:
+    async def get(self, key: str) -> dict[str, Any] | None:
         """Retrieve a value from the cache."""
         ...
 
-    async def set(self, key: str, value: Any, debug_data: dict | None = None) -> None:
+    async def set(self, key: str, data: dict[str, Any]) -> None:
         """Write a value into the cache."""
         ...

--- a/tests/unit/indexing/cache/test_file_pipeline_cache.py
+++ b/tests/unit/indexing/cache/test_file_pipeline_cache.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import unittest
+from typing import cast
 
 from graphrag.index.cache import (
     JsonPipelineCache,
@@ -71,6 +72,6 @@ class TestFilePipelineCache(unittest.IsolatedAsyncioTestCase):
         await self.cache.set("test1", test1)
         await self.cache.set("test2", test2)
         await self.cache.set("test3", test3)
-        assert (await self.cache.get("test1"))["result"] == test1
-        assert (await self.cache.get("test2"))["result"] == test2
-        assert (await self.cache.get("test3"))["result"] == test3
+        assert cast(dict, (await self.cache.get("test1")))["result"] == test1
+        assert cast(dict, (await self.cache.get("test2")))["result"] == test2
+        assert cast(dict, (await self.cache.get("test3")))["result"] == test3

--- a/tests/unit/indexing/cache/test_file_pipeline_cache.py
+++ b/tests/unit/indexing/cache/test_file_pipeline_cache.py
@@ -44,22 +44,22 @@ class TestFilePipelineCache(unittest.IsolatedAsyncioTestCase):
         assert len(files) == 0
 
     async def test_child_cache(self):
-        await self.cache.set("test1", "test1")
+        await self.cache.set("test1", {"value": "test1"})
         assert os.path.exists(f"{TEMP_DIR}/test1")
 
         child = self.cache.child("test")
         assert os.path.exists(f"{TEMP_DIR}/test")
 
-        await child.set("test2", "test2")
+        await child.set("test2", {"value": "test2"})
         assert os.path.exists(f"{TEMP_DIR}/test/test2")
 
-        await self.cache.set("test1", "test1")
+        await self.cache.set("test1", {"value": "test1"})
         await self.cache.delete("test1")
         assert not os.path.exists(f"{TEMP_DIR}/test1")
 
     async def test_cache_has(self):
         test1 = "this is a test file"
-        await self.cache.set("test1", test1)
+        await self.cache.set("test1", {"value": test1})
 
         assert await self.cache.has("test1")
         assert not await self.cache.has("NON_EXISTENT")
@@ -69,9 +69,13 @@ class TestFilePipelineCache(unittest.IsolatedAsyncioTestCase):
         test1 = "this is a test file"
         test2 = "\\n test"
         test3 = "\\\\\\"
-        await self.cache.set("test1", test1)
-        await self.cache.set("test2", test2)
-        await self.cache.set("test3", test3)
-        assert cast(dict, (await self.cache.get("test1")))["result"] == test1
-        assert cast(dict, (await self.cache.get("test2")))["result"] == test2
-        assert cast(dict, (await self.cache.get("test3")))["result"] == test3
+        await self.cache.set("test1", {"result": test1})
+        await self.cache.set("test2", {"result": test2})
+        await self.cache.set("test3", {"result": test3})
+
+        res1 = await self.cache.get("test1")
+        res2 = await self.cache.get("test2")
+        res3 = await self.cache.get("test3")
+        assert cast(dict, res1)["result"] == test1
+        assert cast(dict, res2)["result"] == test2
+        assert cast(dict, res3)["result"] == test3

--- a/tests/unit/indexing/cache/test_file_pipeline_cache.py
+++ b/tests/unit/indexing/cache/test_file_pipeline_cache.py
@@ -71,6 +71,6 @@ class TestFilePipelineCache(unittest.IsolatedAsyncioTestCase):
         await self.cache.set("test1", test1)
         await self.cache.set("test2", test2)
         await self.cache.set("test3", test3)
-        assert await self.cache.get("test1") == test1
-        assert await self.cache.get("test2") == test2
-        assert await self.cache.get("test3") == test3
+        assert (await self.cache.get("test1"))["result"] == test1
+        assert (await self.cache.get("test2"))["result"] == test2
+        assert (await self.cache.get("test3"))["result"] == test3

--- a/tests/unit/llm/__init__.py
+++ b/tests/unit/llm/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License

--- a/tests/unit/llm/base/__init__.py
+++ b/tests/unit/llm/base/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License

--- a/tests/unit/llm/base/test_caching_llm.py
+++ b/tests/unit/llm/base/test_caching_llm.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+"""Caching LLM Tests."""
+
+import asyncio
+from typing import Any, cast
+
+from graphrag.llm import CompletionLLM, LLMOutput
+from graphrag.llm.base.caching_llm import CachingLLM
+from graphrag.llm.openai.openai_history_tracking_llm import OpenAIHistoryTrackingLLM
+from graphrag.llm.types import LLMCache
+
+
+class TestCache(LLMCache):
+    def __init__(self):
+        self.cache = {}
+
+    async def has(self, key: str) -> bool:
+        return key in self.cache
+
+    async def get(self, key: str) -> dict | None:
+        return self.cache.get(key)
+
+    async def set(self, key: str, data: dict[str, Any]) -> None:
+        self.cache[key] = data
+
+
+async def mock_responder(input: str, **kwargs: dict) -> LLMOutput:
+    await asyncio.sleep(0.0001)
+    return LLMOutput(output=f"response to [{input}]")
+
+
+def throwing_responder(input: str, **kwargs: dict) -> LLMOutput:
+    raise ValueError
+
+
+mock_responder_llm = cast(CompletionLLM, mock_responder)
+throwing_llm = cast(CompletionLLM, throwing_responder)
+
+
+async def test_caching_llm() -> None:
+    """Test a composite LLM."""
+    llm = CachingLLM(
+        mock_responder_llm, llm_parameters={}, operation="test", cache=TestCache()
+    )
+    response = await llm("input 1")
+    assert response.output == "response to [input 1]"
+    llm.set_delegate(throwing_llm)
+    response = await llm("input 1")
+    assert response.output == "response to [input 1]"
+
+
+async def test_composite_llm() -> None:
+    """Test a composite LLM."""
+    delegate = OpenAIHistoryTrackingLLM(mock_responder_llm)
+    llm = CachingLLM(delegate, llm_parameters={}, operation="test", cache=TestCache())
+
+    response = await llm("input 1")
+    history: list[dict] = cast(list[dict], response.history)
+    assert len(history) == 2
+
+    response = await llm("input 2", history=history)
+    history: list[dict] = cast(list[dict], response.history)
+    assert len(history) == 4

--- a/tests/unit/llm/openai/__init__.py
+++ b/tests/unit/llm/openai/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License

--- a/tests/unit/llm/openai/test_history_tracking_llm.py
+++ b/tests/unit/llm/openai/test_history_tracking_llm.py
@@ -1,18 +1,22 @@
+from typing import cast
 from graphrag.llm.openai.openai_history_tracking_llm import OpenAIHistoryTrackingLLM
-from graphrag.llm.mock.mock_completion_llm import MockCompletionLLM
+from graphrag.llm import CompletionLLM, LLMOutput
 
 async def test_history_tracking_llm() -> None:
-  delegate = MockCompletionLLM(["response 1", "response 2"])
+  async def mock_responder(input: str, **kwargs: dict) -> str:
+    return LLMOutput(output=f"response to [{input}]")
+  
+  delegate = cast(CompletionLLM, mock_responder)
   llm = OpenAIHistoryTrackingLLM(delegate)
 
   response = await llm("input 1")
   assert len(response.history) == 2
   assert response.history[0] == {"role": "user", "content": "input 1"}
-  assert response.history[1] == {"role": "system", "content": "response 1"}
+  assert response.history[1] == {"role": "system", "content": "response to [input 1]"}
 
   response = await llm("input 2", history=response.history)
   assert len(response.history) == 4
   assert response.history[0] == {"role": "user", "content": "input 1"}
-  assert response.history[1] == {"role": "system", "content": "response 1"}
+  assert response.history[1] == {"role": "system", "content": "response to [input 1]"}
   assert response.history[2] == {"role": "user", "content": "input 2"}
-  assert response.history[3] == {"role": "system", "content": "response 2"}
+  assert response.history[3] == {"role": "system", "content": "response to [input 2]"}

--- a/tests/unit/llm/openai/test_history_tracking_llm.py
+++ b/tests/unit/llm/openai/test_history_tracking_llm.py
@@ -1,0 +1,18 @@
+from graphrag.llm.openai.openai_history_tracking_llm import OpenAIHistoryTrackingLLM
+from graphrag.llm.mock.mock_completion_llm import MockCompletionLLM
+
+async def test_history_tracking_llm() -> None:
+  delegate = MockCompletionLLM(["response 1", "response 2"])
+  llm = OpenAIHistoryTrackingLLM(delegate)
+
+  response = await llm("input 1")
+  assert len(response.history) == 2
+  assert response.history[0] == {"role": "user", "content": "input 1"}
+  assert response.history[1] == {"role": "system", "content": "response 1"}
+
+  response = await llm("input 2", history=response.history)
+  assert len(response.history) == 4
+  assert response.history[0] == {"role": "user", "content": "input 1"}
+  assert response.history[1] == {"role": "system", "content": "response 1"}
+  assert response.history[2] == {"role": "user", "content": "input 2"}
+  assert response.history[3] == {"role": "system", "content": "response 2"}

--- a/tests/unit/llm/openai/test_history_tracking_llm.py
+++ b/tests/unit/llm/openai/test_history_tracking_llm.py
@@ -1,22 +1,32 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+"""History-tracking LLM Tests."""
+
+import asyncio
 from typing import cast
-from graphrag.llm.openai.openai_history_tracking_llm import OpenAIHistoryTrackingLLM
+
 from graphrag.llm import CompletionLLM, LLMOutput
+from graphrag.llm.openai.openai_history_tracking_llm import OpenAIHistoryTrackingLLM
+
 
 async def test_history_tracking_llm() -> None:
-  async def mock_responder(input: str, **kwargs: dict) -> str:
-    return LLMOutput(output=f"response to [{input}]")
-  
-  delegate = cast(CompletionLLM, mock_responder)
-  llm = OpenAIHistoryTrackingLLM(delegate)
+    async def mock_responder(input: str, **kwargs: dict) -> LLMOutput:
+        await asyncio.sleep(0.0001)
+        return LLMOutput(output=f"response to [{input}]")
 
-  response = await llm("input 1")
-  assert len(response.history) == 2
-  assert response.history[0] == {"role": "user", "content": "input 1"}
-  assert response.history[1] == {"role": "system", "content": "response to [input 1]"}
+    delegate = cast(CompletionLLM, mock_responder)
+    llm = OpenAIHistoryTrackingLLM(delegate)
 
-  response = await llm("input 2", history=response.history)
-  assert len(response.history) == 4
-  assert response.history[0] == {"role": "user", "content": "input 1"}
-  assert response.history[1] == {"role": "system", "content": "response to [input 1]"}
-  assert response.history[2] == {"role": "user", "content": "input 2"}
-  assert response.history[3] == {"role": "system", "content": "response to [input 2]"}
+    response = await llm("input 1")
+    history: list[dict] = cast(list[dict], response.history)
+    assert len(history) == 2
+    assert history[0] == {"role": "user", "content": "input 1"}
+    assert history[1] == {"role": "system", "content": "response to [input 1]"}
+
+    response = await llm("input 2", history=history)
+    history: list[dict] = cast(list[dict], response.history)
+    assert len(history) == 4
+    assert history[0] == {"role": "user", "content": "input 1"}
+    assert history[1] == {"role": "system", "content": "response to [input 1]"}
+    assert history[2] == {"role": "user", "content": "input 2"}
+    assert history[3] == {"role": "system", "content": "response to [input 2]"}


### PR DESCRIPTION
## Description

This address #615 by including user prompts in the convesation history in the HistoryTrackingLLM.
In addition:
* Update the cache to include history in the cache-key generation
* Update PipelineCache interface to accept a dictionary as value being stored instead of a string + extra data in a dictionary.
* Update the cache to store history as a new field.
* Update the cached_llm to emit history responses.
* Update the glean-loops to use the same response variable so that the history is passed from call to call correctly.
* Update the config reader to allow for zero-glean configs.

## Related Issues

Fixes #615, #613

## Proposed Changes

* Add user prompts to chat history

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes

[Add any additional notes or context that may be helpful for the reviewer(s).]
