### PR TITLE
fix config reader to allow for zero gleans

### DIFF
--- a/.semversioner/next-release/patch-20240726143138162263.json
+++ b/.semversioner/next-release/patch-20240726143138162263.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "update config reader to allow for zero gleans"
+}

--- a/graphrag/config/create_graphrag_config.py
+++ b/graphrag/config/create_graphrag_config.py
@@ -408,6 +408,13 @@ def create_graphrag_config(
             reader.envvar_prefix(Section.entity_extraction),
             reader.use(entity_extraction_config),
         ):
+            max_gleanings = reader.int(Fragment.max_gleanings)
+            max_gleanings = (
+                max_gleanings
+                if max_gleanings is not None
+                else defs.ENTITY_EXTRACTION_MAX_GLEANINGS
+            )
+
             entity_extraction_model = EntityExtractionConfig(
                 llm=hydrate_llm_params(entity_extraction_config, llm_model),
                 parallelization=hydrate_parallelization_params(
@@ -416,8 +423,7 @@ def create_graphrag_config(
                 async_mode=hydrate_async_type(entity_extraction_config, async_mode),
                 entity_types=reader.list("entity_types")
                 or defs.ENTITY_EXTRACTION_ENTITY_TYPES,
-                max_gleanings=reader.int(Fragment.max_gleanings)
-                or defs.ENTITY_EXTRACTION_MAX_GLEANINGS,
+                max_gleanings=max_gleanings,
                 prompt=reader.str("prompt", Fragment.prompt_file),
             )
 
@@ -426,6 +432,10 @@ def create_graphrag_config(
             reader.envvar_prefix(Section.claim_extraction),
             reader.use(claim_extraction_config),
         ):
+            max_gleanings = reader.int(Fragment.max_gleanings)
+            max_gleanings = (
+                max_gleanings if max_gleanings is not None else defs.CLAIM_MAX_GLEANINGS
+            )
             claim_extraction_model = ClaimExtractionConfig(
                 enabled=reader.bool(Fragment.enabled) or defs.CLAIM_EXTRACTION_ENABLED,
                 llm=hydrate_llm_params(claim_extraction_config, llm_model),
@@ -435,8 +445,7 @@ def create_graphrag_config(
                 async_mode=hydrate_async_type(claim_extraction_config, async_mode),
                 description=reader.str("description") or defs.CLAIM_DESCRIPTION,
                 prompt=reader.str("prompt", Fragment.prompt_file),
-                max_gleanings=reader.int(Fragment.max_gleanings)
-                or defs.CLAIM_MAX_GLEANINGS,
+                max_gleanings=max_gleanings,
             )
 
         community_report_config = values.get("community_reports") or {}

--- a/tests/unit/config/test_default_config.py
+++ b/tests/unit/config/test_default_config.py
@@ -454,6 +454,20 @@ class TestDefaultConfig(unittest.TestCase):
         assert config.input is not None
         assert (config.input.file_pattern or "") == ".*\\.txt$"  # type: ignore
 
+    @mock.patch.dict(
+        os.environ,
+        {
+            "GRAPHRAG_LLM_API_KEY": "test",
+            "GRAPHRAG_ENTITY_EXTRACTION_MAX_GLEANINGS": "0",
+            "GRAPHRAG_CLAIM_EXTRACTION_MAX_GLEANINGS": "0",
+        },
+        clear=True,
+    )
+    def test_can_set_gleanings_to_zero(self):
+        parameters = create_graphrag_config()
+        assert parameters.claim_extraction.max_gleanings == 0
+        assert parameters.entity_extraction.max_gleanings == 0
+
     def test_all_env_vars_is_accurate(self):
         env_var_docs_path = Path("docsite/posts/config/env_vars.md")
         query_docs_path = Path("docsite/posts/query/3-cli.md")


### PR DESCRIPTION
## Description

This PR updates the ConfigReader to avoid a `0 or default_value` situation, which was preventing users from setting zero-gleans.

## Related Issues

Fixes #613 

## Proposed Changes

[List the specific changes made in this pull request.]

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes

[Add any additional notes or context that may be helpful for the reviewer(s).]
