### PR TITLE
wrong param

### DIFF
--- a/graphrag/prompt_tune/generator/entity_extraction_prompt.py
+++ b/graphrag/prompt_tune/generator/entity_extraction_prompt.py
@@ -58,8 +58,8 @@ def create_entity_extraction_prompt(
 
     tokens_left = (
         max_token_count
-        - num_tokens_from_string(prompt, model=encoding_model)
-        - num_tokens_from_string(entity_types, model=encoding_model)
+        - num_tokens_from_string(prompt, encoding_model=encoding_model)
+        - num_tokens_from_string(entity_types, encoding_model=encoding_model)
         if entity_types
         else 0
     )


### PR DESCRIPTION
fix bug 
Failed to get encoding for cl100k_base when getting num_tokens_from_string. Fall back to default encoding cl100k_base