### PR TITLE
bugfix: num_tokens_from_string in entity_extraction_prompt should pass encoding_name instead of model in the parameter.

### DIFF
--- a/.semversioner/next-release/patch-20240812074339857781.json
+++ b/.semversioner/next-release/patch-20240812074339857781.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "fixed entity_extraction_prompt use model instead of encoding_name"
+}

--- a/graphrag/prompt_tune/generator/entity_extraction_prompt.py
+++ b/graphrag/prompt_tune/generator/entity_extraction_prompt.py
@@ -58,8 +58,8 @@ def create_entity_extraction_prompt(
 
     tokens_left = (
         max_token_count
-        - num_tokens_from_string(prompt, model=encoding_model)
-        - num_tokens_from_string(entity_types, model=encoding_model)
+        - num_tokens_from_string(prompt, encoding_name=encoding_model)
+        - num_tokens_from_string(entity_types, encoding_name=encoding_model)
         if entity_types
         else 0
     )
@@ -79,7 +79,7 @@ def create_entity_extraction_prompt(
             )
         )
 
-        example_tokens = num_tokens_from_string(example_formatted, model=encoding_model)
+        example_tokens = num_tokens_from_string(example_formatted, encoding_name=encoding_model)
 
         # Ensure at least three examples are included
         if i >= min_examples_required and example_tokens > tokens_left:


### PR DESCRIPTION
<!--
Thanks for contributing to GraphRAG!

Please do not make *Draft* pull requests, as they still notify anyone watching the repo.

Create a pull request when it is ready for review and feedback.

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

## Description

After modifying encoding_model in settings.yaml and call auto prompt tuning, we get
`INFO: Failed to get encoding for o200k_base when getting num_tokens_from_string. Fall back to default encoding cl100k_base`
I believed this is due to `o200k_base` is passed as a llm model instead of encoding_name.

## Related Issues

#903 

## Proposed Changes

Change the parameter in num_tokens_from_string from model to encoding_name.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes

[Add any additional notes or context that may be helpful for the reviewer(s).]
