### PR TITLE
[Improvement] Cut out some duplicates in prompts

### DIFF
--- a/graphrag/index/graph/extractors/community_reports/prompts.py
+++ b/graphrag/index/graph/extractors/community_reports/prompts.py
@@ -106,45 +106,4 @@ Use the following text for your answer. Do not make anything up in your answer.
 Text:
 {input_text}
 
-The report should include the following sections:
-
-- TITLE: community's name that represents its key entities - title should be short but specific. When possible, include representative named entities in the title.
-- SUMMARY: An executive summary of the community's overall structure, how its entities are related to each other, and significant information associated with its entities.
-- IMPACT SEVERITY RATING: a float score between 0-10 that represents the severity of IMPACT posed by entities within the community.  IMPACT is the scored importance of a community.
-- RATING EXPLANATION: Give a single sentence explanation of the IMPACT severity rating.
-- DETAILED FINDINGS: A list of 5-10 key insights about the community. Each insight should have a short summary followed by multiple paragraphs of explanatory text grounded according to the grounding rules below. Be comprehensive.
-
-Return output as a well-formed JSON-formatted string with the following format:
-    {{
-        "title": <report_title>,
-        "summary": <executive_summary>,
-        "rating": <impact_severity_rating>,
-        "rating_explanation": <rating_explanation>,
-        "findings": [
-            {{
-                "summary":<insight_1_summary>,
-                "explanation": <insight_1_explanation>
-            }},
-            {{
-                "summary":<insight_2_summary>,
-                "explanation": <insight_2_explanation>
-            }}
-        ]
-    }}
-
-# Grounding Rules
-
-Points supported by data should list their data references as follows:
-
-"This is an example sentence supported by multiple data references [Data: <dataset name> (record ids); <dataset name> (record ids)]."
-
-Do not list more than 5 record ids in a single reference. Instead, list the top 5 most relevant record ids and add "+more" to indicate that there are more.
-
-For example:
-"Person X is the owner of Company Y and subject to many allegations of wrongdoing [Data: Reports (1), Entities (5, 7); Relationships (23); Claims (7, 2, 34, 64, 46, +more)]."
-
-where 1, 5, 7, 23, 2, 34, 46, and 64 represent the id (not the index) of the relevant data record.
-
-Do not include information where the supporting evidence for it is not provided.
-
 Output:"""

--- a/graphrag/query/structured_search/global_search/map_system_prompt.py
+++ b/graphrag/query/structured_search/global_search/map_system_prompt.py
@@ -46,37 +46,4 @@ Do not include information where the supporting evidence for it is not provided.
 ---Data tables---
 
 {context_data}
-
----Goal---
-
-Generate a response consisting of a list of key points that responds to the user's question, summarizing all relevant information in the input data tables.
-
-You should use the data provided in the data tables below as the primary context for generating the response.
-If you don't know the answer or if the input data tables do not contain sufficient information to provide an answer, just say so. Do not make anything up.
-
-Each key point in the response should have the following element:
-- Description: A comprehensive description of the point.
-- Importance Score: An integer score between 0-100 that indicates how important the point is in answering the user's question. An 'I don't know' type of response should have a score of 0.
-
-The response shall preserve the original meaning and use of modal verbs such as "shall", "may" or "will".
-
-Points supported by data should list the relevant reports as references as follows:
-"This is an example sentence supported by data references [Data: Reports (report ids)]"
-
-**Do not list more than 5 record ids in a single reference**. Instead, list the top 5 most relevant record ids and add "+more" to indicate that there are more.
-
-For example:
-"Person X is the owner of Company Y and subject to many allegations of wrongdoing [Data: Reports (2, 7, 64, 46, 34, +more)]. He is also CEO of company X [Data: Reports (1, 3)]"
-
-where 1, 2, 3, 7, 34, 46, and 64 represent the id (not the index) of the relevant data report in the provided tables.
-
-Do not include information where the supporting evidence for it is not provided.
-
-The response should be JSON formatted as follows:
-{{
-    "points": [
-        {{"description": "Description of point 1 [Data: Reports (report ids)]", "score": score_value}},
-        {{"description": "Description of point 2 [Data: Reports (report ids)]", "score": score_value}}
-    ]
-}}
 """

--- a/graphrag/query/structured_search/global_search/reduce_system_prompt.py
+++ b/graphrag/query/structured_search/global_search/reduce_system_prompt.py
@@ -36,40 +36,9 @@ where 1, 2, 3, 7, 34, 46, and 64 represent the id (not the index) of the relevan
 Do not include information where the supporting evidence for it is not provided.
 
 
----Target response length and format---
-
-{response_type}
-
-
 ---Analyst Reports---
 
 {report_data}
-
-
----Goal---
-
-Generate a response of the target length and format that responds to the user's question, summarize all the reports from multiple analysts who focused on different parts of the dataset.
-
-Note that the analysts' reports provided below are ranked in the **descending order of importance**.
-
-If you don't know the answer or if the provided reports do not contain sufficient information to provide an answer, just say so. Do not make anything up.
-
-The final response should remove all irrelevant information from the analysts' reports and merge the cleaned information into a comprehensive answer that provides explanations of all the key points and implications appropriate for the response length and format.
-
-The response shall preserve the original meaning and use of modal verbs such as "shall", "may" or "will".
-
-The response should also preserve all the data references previously included in the analysts' reports, but do not mention the roles of multiple analysts in the analysis process.
-
-**Do not list more than 5 record ids in a single reference**. Instead, list the top 5 most relevant record ids and add "+more" to indicate that there are more.
-
-For example:
-
-"Person X is the owner of Company Y and subject to many allegations of wrongdoing [Data: Reports (2, 7, 34, 46, 64, +more)]. He is also CEO of company X [Data: Reports (1, 3)]"
-
-where 1, 2, 3, 7, 34, 46, and 64 represent the id (not the index) of the relevant data record.
-
-Do not include information where the supporting evidence for it is not provided.
-
 
 ---Target response length and format---
 

--- a/graphrag/query/structured_search/local_search/system_prompt.py
+++ b/graphrag/query/structured_search/local_search/system_prompt.py
@@ -29,37 +29,9 @@ where 15, 16, 1, 5, 7, 23, 2, 7, 34, 46, and 64 represent the id (not the index)
 
 Do not include information where the supporting evidence for it is not provided.
 
-
----Target response length and format---
-
-{response_type}
-
-
 ---Data tables---
 
 {context_data}
-
-
----Goal---
-
-Generate a response of the target length and format that responds to the user's question, summarizing all information in the input data tables appropriate for the response length and format, and incorporating any relevant general knowledge.
-
-If you don't know the answer, just say so. Do not make anything up.
-
-Points supported by data should list their data references as follows:
-
-"This is an example sentence supported by multiple data references [Data: <dataset name> (record ids); <dataset name> (record ids)]."
-
-Do not list more than 5 record ids in a single reference. Instead, list the top 5 most relevant record ids and add "+more" to indicate that there are more.
-
-For example:
-
-"Person X is the owner of Company Y and subject to many allegations of wrongdoing [Data: Sources (15, 16), Reports (1), Entities (5, 7); Relationships (23); Claims (2, 7, 34, 46, 64, +more)]."
-
-where 15, 16, 1, 5, 7, 23, 2, 7, 34, 46, and 64 represent the id (not the index) of the relevant data record.
-
-Do not include information where the supporting evidence for it is not provided.
-
 
 ---Target response length and format---
 


### PR DESCRIPTION

## Description

global_search/map_system_prompt.py, reduce_system_prompt.py, community_reports/prompts.py have many repetitive parts, which will increase the context_size of llm. Waste token, after multiple model tests, the effect of removing the duplicate part does not make any difference

## Proposed Changes

[List the specific changes made in this pull request.]

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).


