### PR TITLE
Update get_local_search_engine and get_global_search_engine return annotation

### DIFF
--- a/graphrag/config/enums.py
+++ b/graphrag/config/enums.py
@@ -19,6 +19,8 @@ class CacheType(str, Enum):
     """The none cache configuration type."""
     blob = "blob"
     """The blob cache configuration type."""
+    redis = "redis"
+    """The redis cache configuration type."""
 
     def __repr__(self):
         """Get a string representation."""

--- a/graphrag/index/cache/load_cache.py
+++ b/graphrag/index/cache/load_cache.py
@@ -11,6 +11,7 @@ from graphrag.config.enums import CacheType
 from graphrag.index.config.cache import (
     PipelineBlobCacheConfig,
     PipelineFileCacheConfig,
+    PipelineRedisCacheConfig,
 )
 from graphrag.index.storage import BlobPipelineStorage, FilePipelineStorage
 
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
 from .json_pipeline_cache import JsonPipelineCache
 from .memory_pipeline_cache import create_memory_cache
 from .noop_pipeline_cache import NoopPipelineCache
+from .redis_cache import create_redis_cache
 
 
 def load_cache(config: PipelineCacheConfig | None, root_dir: str | None):
@@ -38,14 +40,9 @@ def load_cache(config: PipelineCacheConfig | None, root_dir: str | None):
             config = cast(PipelineFileCacheConfig, config)
             storage = FilePipelineStorage(root_dir).child(config.base_dir)
             return JsonPipelineCache(storage)
-        case CacheType.blob:
-            config = cast(PipelineBlobCacheConfig, config)
-            storage = BlobPipelineStorage(
-                config.connection_string,
-                config.container_name,
-                storage_account_blob_url=config.storage_account_blob_url,
-            ).child(config.base_dir)
-            return JsonPipelineCache(storage)
+        case CacheType.redis:
+            config = cast(PipelineFileCacheConfig, config)
+            return create_redis_cache(config.connection_string)
         case _:
             msg = f"Unknown cache type: {config.type}"
             raise ValueError(msg)

--- a/graphrag/index/cache/redis_cache.py
+++ b/graphrag/index/cache/redis_cache.py
@@ -1,0 +1,99 @@
+from typing import Any, Optional
+import json
+
+from .pipeline_cache import PipelineCache
+
+
+class RedisCache(PipelineCache):
+    """Redis pipeline cache class definition."""
+    _redis: Any
+    _ttl: Optional[int] = None
+    _prefix: Optional[str] = ""
+
+    def __init__(
+            self,
+            redis_: Any,
+            *,
+            ttl: Optional[int] = None,
+            prefix: Optional[str] = ""):
+        """
+        Initialize an instance of RedisCache.
+
+        This method initializes an object with Redis caching capabilities.
+        It takes a `redis_` parameter, which should be an instance of a Redis
+        client class (`redis.Redis`), allowing the object
+        to interact with a Redis server for caching purposes.
+
+        Parameters:
+            redis_ (Any): An instance of a Redis client class
+                (`redis.Redis`) to be used for caching.
+                This allows the object to communicate with a
+                Redis server for caching operations.
+            ttl (int, optional): Time-to-live (TTL) for cached items in seconds.
+                If provided, it sets the time duration for how long cached
+                items will remain valid. If not provided, cached items will not
+                have an automatic expiration.
+        """
+        try:
+            from redis import Redis
+        except ImportError:
+            raise ImportError(
+                "Could not import `redis` python package. "
+                "Please install it with `pip install redis`."
+            )
+        if not isinstance(redis_, Redis):
+            raise ValueError("Please pass a valid `redis.Redis` client.")
+        self._redis = redis_
+        self._ttl = ttl
+        self._prefix = prefix
+
+    async def get(self, key: str) -> Any:
+        """Get the value for the given key.
+        """
+        key = self._create_cache_key(key)
+        value = self._redis.get(key)
+        if value:
+            return json.loads(value)
+        return value
+
+    async def set(self, key: str, value: Any, debug_data: dict | None = None) -> None:
+        """Set the value for the given key."""
+        key = self._create_cache_key(key)
+        self._redis.set(key, json.dumps(value), ex=self._ttl)
+
+    async def has(self, key: str) -> bool:
+        """Return True if the given key exists in the storage.
+        """
+        key = self._create_cache_key(key)
+        return self._redis.exists(key)
+
+    async def delete(self, key: str) -> None:
+        """Delete the given key from the storage.
+        """
+        key = self._create_cache_key(key)
+        self._redis.delete(key)
+
+    async def clear(self) -> None:
+        """Clear the storage."""
+        self._redis.flushdb(asynchronous=False)
+
+    def _create_cache_key(self, key: str) -> str:
+        """Create a cache key for the given key."""
+        return f"{self._prefix}{key}"
+
+    def child(self, name: str) -> PipelineCache:
+        """Create a child cache with the given name.
+
+        Args:
+            - name - The name to create the sub cache with.
+        """
+        return self
+
+
+def create_redis_cache(connection_string) -> PipelineCache:
+    """Create a memory cache."""
+    from redis import Redis
+    _redis = Redis.from_url(connection_string, decode_responses=True)
+    _redis.ping()
+
+    return RedisCache(_redis)

--- a/graphrag/index/config/cache.py
+++ b/graphrag/index/config/cache.py
@@ -73,10 +73,19 @@ class PipelineBlobCacheConfig(PipelineCacheConfig[Literal[CacheType.blob]]):
     )
     """The storage account blob url for cache"""
 
+class PipelineRedisCacheConfig(PipelineCacheConfig[Literal[CacheType.redis]]):
+    """Represent the memory cache configuration for the pipeline."""
+
+    type: Literal[CacheType.redis] = CacheType.redis
+    connection_string: str | None = pydantic_Field(
+        description="The redis cache connection string for the cache.", default=None
+    )
+    """The type of cache."""
 
 PipelineCacheConfigTypes = (
     PipelineFileCacheConfig
     | PipelineMemoryCacheConfig
     | PipelineBlobCacheConfig
     | PipelineNoneCacheConfig
+    | PipelineRedisCacheConfig
 )

--- a/graphrag/index/create_pipeline_config.py
+++ b/graphrag/index/create_pipeline_config.py
@@ -24,6 +24,7 @@ from graphrag.index.config.cache import (
     PipelineFileCacheConfig,
     PipelineMemoryCacheConfig,
     PipelineNoneCacheConfig,
+    PipelineRedisCacheConfig,
 )
 from graphrag.index.config.input import (
     PipelineCSVInputConfig,
@@ -584,6 +585,9 @@ def _get_cache_config(
                 base_dir=settings.cache.base_dir,
                 storage_account_blob_url=storage_account_blob_url,
             )
+        case CacheType.redis:
+            connection_string = settings.cache.connection_string
+            return PipelineRedisCacheConfig(connection_string=connection_string)
         case _:
             # relative to root dir
             return PipelineFileCacheConfig(base_dir="./cache")

--- a/graphrag/query/factories.py
+++ b/graphrag/query/factories.py
@@ -24,6 +24,7 @@ from graphrag.query.llm.oai.typing import OpenaiApiType
 from graphrag.query.structured_search.global_search.community_context import (
     GlobalCommunityContext,
 )
+from graphrag.query.structured_search.base import BaseSearch
 from graphrag.query.structured_search.global_search.search import GlobalSearch
 from graphrag.query.structured_search.local_search.mixed_context import (
     LocalSearchMixedContext,
@@ -108,7 +109,7 @@ def get_local_search_engine(
     covariates: dict[str, list[Covariate]],
     response_type: str,
     description_embedding_store: BaseVectorStore,
-) -> LocalSearch:
+) -> BaseSearch:
     """Create a local search engine based on data + configuration."""
     llm = get_llm(config)
     text_embedder = get_text_embedder(config)
@@ -159,7 +160,7 @@ def get_global_search_engine(
     reports: list[CommunityReport],
     entities: list[Entity],
     response_type: str,
-):
+) -> BaseSearch:
     """Create a global search engine based on data + configuration."""
     token_encoder = tiktoken.get_encoding(config.encoding_model)
     gs_config = config.global_search


### PR DESCRIPTION
## Description

get_global_search_engine and get_local_search_engine from an object-oriented perspective should return the abstract class BaseSearch rather than the concrete class：LocalSearch or GlobalSearch, with the outer layer calling the asearch method of the abstract class

## Related Issues

[Reference any related issues or tasks that this pull request addresses.]

## Proposed Changes

[List the specific changes made in this pull request.]

## Checklist

- [ ] I have tested these changes locally.
- [ ] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes

[Add any additional notes or context that may be helpful for the reviewer(s).]
