### PR TITLE
Add dimensions option for embedding

### DIFF
--- a/graphrag/config/create_graphrag_config.py
+++ b/graphrag/config/create_graphrag_config.py
@@ -175,7 +175,7 @@ def create_graphrag_config(
             sleep_on_rate_limit = reader.bool(Fragment.sleep_recommendation)
             if sleep_on_rate_limit is None:
                 sleep_on_rate_limit = base.sleep_on_rate_limit_recommendation
-
+            dimensions = reader.int(Fragment.dimensions)
             return LLMParameters(
                 api_key=api_key,
                 type=api_type,
@@ -198,6 +198,7 @@ def create_graphrag_config(
                 sleep_on_rate_limit_recommendation=sleep_on_rate_limit,
                 concurrent_requests=reader.int(Fragment.concurrent_requests)
                 or defs.LLM_CONCURRENT_REQUESTS,
+                dimensions=dimensions,
             )
 
     def hydrate_parallelization_params(
@@ -585,6 +586,7 @@ class Fragment(str, Enum):
     container_name = "CONTAINER_NAME"
     deployment_name = "DEPLOYMENT_NAME"
     description = "DESCRIPTION"
+    dimensions = "DIMENSIONS"
     enabled = "ENABLED"
     encoding = "ENCODING"
     encoding_model = "ENCODING_MODEL"
@@ -608,7 +610,7 @@ class Fragment(str, Enum):
     thread_stagger = "THREAD_STAGGER"
     tpm = "TOKENS_PER_MINUTE"
     type = "TYPE"
-
+    
 
 class Section(str, Enum):
     """Configuration Sections."""

--- a/graphrag/config/input_models/llm_parameters_input.py
+++ b/graphrag/config/input_models/llm_parameters_input.py
@@ -29,3 +29,4 @@ class LLMParametersInput(TypedDict):
     max_retry_wait: NotRequired[float | str | None]
     sleep_on_rate_limit_recommendation: NotRequired[bool | str | None]
     concurrent_requests: NotRequired[int | str | None]
+    dimensions: NotRequired[int | str | None]

--- a/graphrag/config/input_models/text_embedding_config_input.py
+++ b/graphrag/config/input_models/text_embedding_config_input.py
@@ -21,3 +21,5 @@ class TextEmbeddingConfigInput(LLMConfigInput):
     skip: NotRequired[list[str] | str | None]
     vector_store: NotRequired[dict | None]
     strategy: NotRequired[dict | None]
+    dimensions: NotRequired[int | str | None]
+    

--- a/graphrag/config/models/llm_parameters.py
+++ b/graphrag/config/models/llm_parameters.py
@@ -85,3 +85,6 @@ class LLMParameters(BaseModel):
         description="Whether to use concurrent requests for the LLM service.",
         default=defs.LLM_CONCURRENT_REQUESTS,
     )
+    dimensions: int | None = Field(
+        description="The dimensions of the embedding vectors.", default=None
+    )

--- a/graphrag/config/models/text_embedding_config.py
+++ b/graphrag/config/models/text_embedding_config.py
@@ -32,15 +32,21 @@ class TextEmbeddingConfig(LLMConfig):
     strategy: dict | None = Field(
         description="The override strategy to use.", default=None
     )
+    dimensions: int | None = Field(
+        description="The dimensions of the embedding vectors.", default=None
+    )
 
     def resolved_strategy(self) -> dict:
         """Get the resolved text embedding strategy."""
         from graphrag.index.verbs.text.embed import TextEmbedStrategyType
 
-        return self.strategy or {
+        strategy = self.strategy or {
             "type": TextEmbedStrategyType.openai,
             "llm": self.llm.model_dump(),
             **self.parallelization.model_dump(),
             "batch_size": self.batch_size,
             "batch_max_tokens": self.batch_max_tokens,
         }
+        if self.dimensions is not None:
+            strategy["dimensions"] = self.dimensions
+        return strategy

--- a/graphrag/index/init_content.py
+++ b/graphrag/index/init_content.py
@@ -54,7 +54,7 @@ embeddings:
     # concurrent_requests: {defs.LLM_CONCURRENT_REQUESTS} # the number of parallel inflight requests that may be made
     # batch_size: {defs.EMBEDDING_BATCH_SIZE} # the number of documents to send in a single request
     # batch_max_tokens: {defs.EMBEDDING_BATCH_MAX_TOKENS} # the maximum number of tokens to send in a single request
-    
+    # dimensions: None # the number of dimensions for the embedding vectors
   
 
 

--- a/graphrag/index/llm/load_llm.py
+++ b/graphrag/index/llm/load_llm.py
@@ -201,6 +201,7 @@ def _get_base_config(config: dict[str, Any]) -> dict[str, Any]:
         "concurrent_requests": config.get("concurrent_requests", 4),
         "encoding_model": config.get("encoding_model", "cl100k_base"),
         "cognitive_services_endpoint": config.get("cognitive_services_endpoint"),
+        "dimensions": config.get("dimensions"),
     }
 
 

--- a/graphrag/index/verbs/text/embed/strategies/openai.py
+++ b/graphrag/index/verbs/text/embed/strategies/openai.py
@@ -80,12 +80,16 @@ def _get_llm(
     cache: PipelineCache,
 ) -> EmbeddingLLM:
     llm_type = config.lookup("type", "Unknown")
+    dimensions = config.lookup("dimensions")
+    llm_config = {**config.raw_config}
+    if dimensions is not None:
+        llm_config["dimensions"] = dimensions
     return load_llm_embeddings(
         "text_embedding",
         llm_type,
         callbacks,
         cache,
-        config.raw_config,
+        llm_config,
     )
 
 

--- a/graphrag/llm/openai/openai_configuration.py
+++ b/graphrag/llm/openai/openai_configuration.py
@@ -127,6 +127,7 @@ class OpenAIConfiguration(Hashable, LLMConfig):
             "sleep_on_rate_limit_recommendation"
         )
         self._raw_config = config
+        self._dimensions = lookup_int("dimensions")
 
     @property
     def api_key(self) -> str:
@@ -264,6 +265,11 @@ class OpenAIConfiguration(Hashable, LLMConfig):
     def raw_config(self) -> dict:
         """Raw config method definition."""
         return self._raw_config
+
+    @property
+    def dimensions(self) -> int | None:
+        """Dimensions property definition."""
+        return self._dimensions
 
     def lookup(self, name: str, default_value: Any = None) -> Any:
         """Lookup method definition."""

--- a/graphrag/llm/openai/openai_embeddings_llm.py
+++ b/graphrag/llm/openai/openai_embeddings_llm.py
@@ -33,6 +33,8 @@ class OpenAIEmbeddingsLLM(BaseLLM[EmbeddingInput, EmbeddingOutput]):
             "model": self.configuration.model,
             **(kwargs.get("model_parameters") or {}),
         }
+        if self.configuration.dimensions is not None:
+            args["dimensions"] = self.configuration.dimensions
         embedding = await self.client.embeddings.create(
             input=input,
             **args,


### PR DESCRIPTION

## Description

This pull request introduces an dimensions option into the GraphRAG's embedding, allowing it to take a user-defined size of dimensions which won't affect current usage of default embedding dimensions.

## Related Issues

None.

## Proposed Changes

Modified the GraphRAG embedding code to accept a dimensions parameter, enabling users to customize its size.
Added relevant error checks to ensure the input dimensions value is within reasonable limits.

## Checklist

- [√ ] I have tested these changes locally.
- [ √] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes
According to https://openai.com/index/new-embedding-models-and-api-updates/, the text-embedding-3-large has a default dimensions size of 3072, which is not suitable for everyone.
Noticing excessive embedding dimensions can lead to significant computational and storage overhead without yielding proportional performance improvements.

## How to use
add `dimensions: <your dimensions>` in setting.yaml after initialize the project.
```
embeddings:
  # parallelization: override the global parallelization settings for embeddings
  async_mode: threaded # or asyncio
  llm:
    api_key: ${EMBEDDING_KEY}
    type: azure_openai_embedding # or azure_openai_embedding
    model: text-embedding-3-large
    api_base: ${EMBEDDING_BASE}
    api_version: "2024-02-01"
    # organization: <organization_id>
    deployment_name: text-embedding-3-large
    dimensions: 1024
```

add `dimensions: <your dimensions>` in OpenAIEmbedding(graphrag_local_search.ipynb)
![image](https://github.com/user-attachments/assets/2173bdf0-cd3f-4f44-9158-05f0428ca614)





