### PR TITLE
fix: Skip `resolve_timestamp_path` when using --data in local search

### DIFF
--- a/.semversioner/next-release/patch-20240829071508331905.json
+++ b/.semversioner/next-release/patch-20240829071508331905.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "<Skip  when using --data in local search>."
+}

--- a/graphrag/query/api.py
+++ b/graphrag/query/api.py
@@ -149,7 +149,7 @@ async def global_search_streaming(
 
 @validate_call(config={"arbitrary_types_allowed": True})
 async def local_search(
-    root_dir: str | None,
+    data_path: Path,
     config: GraphRagConfig,
     nodes: pd.DataFrame,
     entities: pd.DataFrame,
@@ -196,9 +196,7 @@ async def local_search(
 
     _entities = read_indexer_entities(nodes, entities, community_level)
 
-    base_dir = Path(str(root_dir)) / config.storage.base_dir
-    resolved_base_dir = resolve_timestamp_path(base_dir)
-    lancedb_dir = resolved_base_dir / "lancedb"
+    lancedb_dir = data_path / "lancedb"
     vector_store_args.update({"db_uri": str(lancedb_dir)})
     description_embedding_store = _get_embedding_description_store(
         entities=_entities,
@@ -227,7 +225,7 @@ async def local_search(
 
 @validate_call(config={"arbitrary_types_allowed": True})
 async def local_search_streaming(
-    root_dir: str | None,
+    data_path: Path,
     config: GraphRagConfig,
     nodes: pd.DataFrame,
     entities: pd.DataFrame,
@@ -271,9 +269,7 @@ async def local_search_streaming(
 
     _entities = read_indexer_entities(nodes, entities, community_level)
 
-    base_dir = Path(str(root_dir)) / config.storage.base_dir
-    resolved_base_dir = resolve_timestamp_path(base_dir)
-    lancedb_dir = resolved_base_dir / "lancedb"
+    lancedb_dir = data_path / "lancedb"
     vector_store_args.update({"db_uri": str(lancedb_dir)})
     description_embedding_store = _get_embedding_description_store(
         entities=_entities,

--- a/graphrag/query/cli.py
+++ b/graphrag/query/cli.py
@@ -137,7 +137,7 @@ def run_local_search(
             context_data = None
             get_context_data = True
             async for stream_chunk in api.local_search_streaming(
-                root_dir=root_dir,
+                data_path=data_path,
                 config=config,
                 nodes=final_nodes,
                 entities=final_entities,
@@ -163,7 +163,7 @@ def run_local_search(
     # not streaming
     response, context_data = asyncio.run(
         api.local_search(
-            root_dir=root_dir,
+            data_path=data_path,
             config=config,
             nodes=final_nodes,
             entities=final_entities,


### PR DESCRIPTION
## Description
The errors during the indexing process that led to rebuilding once again have been quite frustrating, so I specified the `--resume` parameter in the CLI to avoid repeatedly consuming tokens to build the index. However, instead of using the timestamp in the example, I customized a name, like _acc_ (since there are too many previously generated timestamp directories under this directory, a custom name makes it more noticeable). After successfully completing the index build, I attempted to use global search with the `--data` parameter, and it worked well. However, when I used local search with the same `--data` parameter, I received a ValueError.

For example, the CLI command is as follows:
```python
python -m graphrag.query \
--root ./ragtest \
--data ./ragtest/output/acc/artifacts \
--method local \
"Who is Scrooge, and what are his main relationships?"
```

The ValueError originates from graphrag/config/resolve_timestamp_path.py at lines 76-78:
```python
if len(timestamp_dirs) == 0:
    msg = f"No timestamp directories found in {parent_dir} that match {pattern.pattern}."
    raise ValueError(msg)
```

This is very confusing since I didn’t use a timestamp as the value for the `--data` parameter, so why is it prompting that none were found?
Upon inspecting the code, I discovered that in the method `_configure_paths_and_settings` within the graphrag/query/cli.py file, a conditional check is already performed based on the `--data` parameter:
```python
def _configure_paths_and_settings(
    data_dir: str | None,
    root_dir: str | None,
    config_filepath: str | None,
) -> tuple[str, str | None, GraphRagConfig]:
    config = _create_graphrag_config(root_dir, config_filepath)
    if data_dir is None and root_dir is None:
        msg = "Either data_dir or root_dir must be provided."
        raise ValueError(msg)
    if data_dir is None:
        base_dir = Path(str(root_dir)) / config.storage.base_dir
        data_dir = str(resolve_timestamp_path(base_dir))
    return data_dir, root_dir, config
```

Further on, the local search methods in both graphrag/query/cli.py and graphrag/query/api.py repeatedly call `resolve_timestamp_path`, which led to the ValueError mentioned earlier.

As a result, I made modifications to the code and submitted this PR.

I modified the local_search function’s parameters to pass in the data_path parameter, which was previously handled in `_configure_paths_and_settings` in cli.py, as `resolved_base_dir`. This is only used for the `lancedb_dir` variable.

## Related Issues
I did not find any related issues.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

---
####	Thank you for taking the time to review this PR. 
####	I appreciate your consideration of these changes.
