### PR TITLE
Add an "overwrite" parameter, eliminating the need to rebuild the vector store each time

### DIFF
--- a/graphrag/query/input/loaders/dfs.py
+++ b/graphrag/query/input/loaders/dfs.py
@@ -73,6 +73,7 @@ def read_entities(
 def store_entity_semantic_embeddings(
     entities: list[Entity],
     vectorstore: BaseVectorStore,
+    overwrite: bool = True
 ) -> BaseVectorStore:
     """Store entity semantic embeddings in a vectorstore."""
     documents = [
@@ -88,7 +89,7 @@ def store_entity_semantic_embeddings(
         )
         for entity in entities
     ]
-    vectorstore.load_documents(documents=documents)
+    vectorstore.load_documents(documents=documents, overwrite=overwrite)
     return vectorstore
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to GraphRAG!

Please do not make *Draft* pull requests, as they still notify anyone watching the repo.

Create a pull request when it is ready for review and feedback.

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

## Description

Add the "overwrite" parameter so that the vector store does not need to be rebuilt every time a query is made.

code example:

```python
description_embedding_store = LanceDBVectorStore(
        collection_name="entity_description_embeddings")

description_embedding_store.connect(db_uri=LANCEDB_URI)

entity_description_embeddings = dfs.store_entity_semantic_embeddings(
        entities=[],
        vectorstore=description_embedding_store,
        overwrite=False
)
```

## Related Issues

fix #1048 

## Proposed Changes
Function adds the "overwrite" parameter.


## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes


