### PR TITLE
Adding run_id to fix the error during the initilization step of promp…

### DIFF
--- a/graphrag/prompt_tune/cli.py
+++ b/graphrag/prompt_tune/cli.py
@@ -3,8 +3,8 @@
 
 """Command line interface for the fine_tune module."""
 
-from pathlib import Path
 import time
+from pathlib import Path
 
 from graphrag.config import load_config
 from graphrag.index.progress import PrintProgressReporter

--- a/graphrag/prompt_tune/cli.py
+++ b/graphrag/prompt_tune/cli.py
@@ -4,6 +4,7 @@
 """Command line interface for the fine_tune module."""
 
 from pathlib import Path
+import time
 
 from graphrag.config import load_config
 from graphrag.index.progress import PrintProgressReporter
@@ -50,7 +51,8 @@ async def prompt_tune(
     """
     reporter = PrintProgressReporter("")
     root_path = Path(root).resolve()
-    graph_config = load_config(root_path, config)
+    run_id = time.strftime("%Y%m%d-%H%M%S")
+    graph_config = load_config(root_path, config, run_id)
 
     prompts = await api.generate_indexing_prompts(
         config=graph_config,


### PR DESCRIPTION
…t_tune

<!--
Thanks for contributing to GraphRAG!

Please do not make *Draft* pull requests, as they still notify anyone watching the repo.

Create a pull request when it is ready for review and feedback.

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

## Description

This is bug fix for prompt_tune when run_id is not defined in the cli.py in prompt_tune

## Related Issues

General Discussion #1147 

## Proposed Changes

Include run_id in the initialization step before calling load_config so that it can safely initialize storage & reporting folders. 

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes

[Add any additional notes or context that may be helpful for the reviewer(s).]
