### PR TITLE
Remove redundant code from error-handling code in GlobalSearch

### DIFF
--- a/.semversioner/next-release/patch-20240919223518903171.json
+++ b/.semversioner/next-release/patch-20240919223518903171.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "remove redundant error-handling code from global-search"
+}

--- a/graphrag/query/structured_search/global_search/search.py
+++ b/graphrag/query/structured_search/global_search/search.py
@@ -218,16 +218,11 @@ class GlobalSearch(BaseSearch):
             try:
                 # parse search response json
                 processed_response = self.parse_search_response(search_response)
-            except ValueError:
-                # Clean up and retry parse
-                try:
-                    # parse search response json
-                    processed_response = self.parse_search_response(search_response)
-                except ValueError:
-                    log.warning(
-                        "Warning: Error parsing search response json - skipping this batch"
-                    )
-                    processed_response = []
+            except ValueError:                
+                log.warning(
+                    "Warning: Error parsing search response json - skipping this batch"
+                )
+                processed_response = []
 
             return SearchResult(
                 response=processed_response,

--- a/graphrag/query/structured_search/global_search/search.py
+++ b/graphrag/query/structured_search/global_search/search.py
@@ -218,7 +218,7 @@ class GlobalSearch(BaseSearch):
             try:
                 # parse search response json
                 processed_response = self.parse_search_response(search_response)
-            except ValueError:                
+            except ValueError:
                 log.warning(
                     "Warning: Error parsing search response json - skipping this batch"
                 )


### PR DESCRIPTION
## Description

The GlobalSearch function `_map_response_single_batch`, used to invoke a method called `clean_up_json` before retrying a parsing operation. This method has been removed, but the retry has not, resulting in code that will raise the same error twice. 

## Related Issues

[Reference any related issues or tasks that this pull request addresses.]

## Proposed Changes

[List the specific changes made in this pull request.]

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes

[Add any additional notes or context that may be helpful for the reviewer(s).]
