### PR TITLE
Allow ci/cd to skip draft PRs

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -23,6 +23,8 @@ env:
 
 jobs:
   python-ci:
+    # skip draft PRs
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         python-version: ["3.10", "3.11"] # add 3.12 once gensim supports it. TODO: watch this issue - https://github.com/piskvorky/gensim/issues/3510

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,6 +5,11 @@ on:
       - "**/main" # Matches branches like feature/main
       - "main" # Matches the main branch
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - "**/main"
       - "main"

--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -23,6 +23,8 @@ env:
 
 jobs:
   python-ci:
+    # skip draft PRs
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         python-version: ["3.10"]

--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -5,6 +5,11 @@ on:
       - "**/main" # Matches branches like feature/main
       - "main" # Matches the main branch
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - "**/main"
       - "main"

--- a/.github/workflows/python-notebook-tests.yml
+++ b/.github/workflows/python-notebook-tests.yml
@@ -23,6 +23,8 @@ env:
 
 jobs:
   python-ci:
+    # skip draft PRs
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         python-version: ["3.10"]

--- a/.github/workflows/python-notebook-tests.yml
+++ b/.github/workflows/python-notebook-tests.yml
@@ -5,6 +5,11 @@ on:
       - "**/main" # Matches branches like feature/main
       - "main" # Matches the main branch
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - "**/main"
       - "main"

--- a/.github/workflows/python-smoke-tests.yml
+++ b/.github/workflows/python-smoke-tests.yml
@@ -23,6 +23,8 @@ env:
 
 jobs:
   python-ci:
+    # skip draft PRs
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         python-version: ["3.10"]

--- a/.github/workflows/python-smoke-tests.yml
+++ b/.github/workflows/python-smoke-tests.yml
@@ -5,6 +5,11 @@ on:
       - "**/main" # Matches branches like feature/main
       - "main" # Matches the main branch
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - "**/main"
       - "main"

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -4,12 +4,13 @@ on:
     branches: [main]
 
 jobs:
-    semver:
-        runs-on: ubuntu-latest
-        steps:
-        - uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
-    
-        - name: Check Semver
-          run: ./scripts/semver-check.sh
+  semver:
+    # skip draft PRs
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Check Semver
+      run: ./scripts/semver-check.sh

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,6 +1,11 @@
 name: Semver Check
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches: [main]
 
 jobs:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -7,6 +7,8 @@ on:
       - "**/*"
 jobs:
   spellcheck:
+    # skip draft PRs
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches: [main]
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     paths:
       - "**/*"
 jobs:


### PR DESCRIPTION
## Description

A small change that will allow the ci/cd to skip draft PRs and allow for better collaboration/reviews without kicking off a ton of ci/cd jobs.

I used [this](https://github.com/reviewdog/action-eslint/issues/29#issuecomment-985939887) post as a reference for the changes and tested them in our repo.

## Proposed Changes

This PR updates the ci/cd code.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).
