### PR TITLE
Add backwards compatibility patch for vector store

### DIFF
--- a/.semversioner/next-release/patch-20241029025329363730.json
+++ b/.semversioner/next-release/patch-20241029025329363730.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "add backwards compatibility patch to vector store."
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
     "ms-python.vscode-pylance",
     "bierner.markdown-mermaid",
     "streetsidesoftware.code-spell-checker",
-    "ronnidc.nunjucks"
+    "ronnidc.nunjucks",
+    "lucien-martijn.parquet-visualizer",
   ]
 }

--- a/tests/fixtures/min-csv/settings.yml
+++ b/tests/fixtures/min-csv/settings.yml
@@ -6,12 +6,11 @@ embeddings:
     type: "lancedb"
     db_uri: "./tests/fixtures/min-csv/lancedb"
     collection_name: "lancedb_ci"
+    overwrite: True
     store_in_table: True
-
     entity_name_description:
       title_column: "name"
       # id_column: "id"
-      # overwrite: true
     # entity_name: ...
     # relationship_description: ...
     # community_report_full_content: ...
@@ -19,7 +18,6 @@ embeddings:
     # community_report_title: ...
     # document_raw_content: ...
     # text_unit_text: ...
-
 
 storage:
   type: file # or blob


### PR DESCRIPTION
## Description

This PR adds a patch to the query engine that will permit queries to run on old indexes where the vector store was never configured. This change will only work when querying old indexes. New indexes will require the vector_store to be defined in the default config file (already defined when users run the `graphrag init` command.

Note: I added a [VSCode extension](https://marketplace.visualstudio.com/items?itemName=lucien-martijn.parquet-visualizer) to the recommended list that enables easy inspection of parquet files.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).