### PR TITLE
allow httpx 0.27

### DIFF
--- a/.semversioner/next-release/patch-20250108184901555481.json
+++ b/.semversioner/next-release/patch-20250108184901555481.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "support vers 0.27 of httpx"
+}

--- a/poetry.lock
+++ b/poetry.lock
@@ -5258,4 +5258,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "1adafa89f86e853b424eb1d66d3434520596e6b1e782c975a497a1c857ceabb9"
+content-hash = "4db71d09c4c4c5558bb9a727c7122a5f3c36c2554a26e4c6d0ecc5cf454739a6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ fnllm = "^0.0.10"
 tenacity = "^9.0.0"
 json-repair = "^0.30.3"
 tqdm = "^4.67.1"
-httpx = "^0.28.1"
+httpx = ">=0.27,<0.29"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "^7.6.9"


### PR DESCRIPTION
## Description

A lot of the libraries in the python ecosystem are still locked on 0.27, creating all kind of dependency conflicts. As far as I could tell by overriding the version locally, there should not be any reason for GraphRAG to require httpx version 0.28.

I was wondering if it would be possible to make the requirements of httpx less strict for GraphRAG

## Proposed Changes

Allow version 0.27.X and 0.28.X version of httpx.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.

## Additional Notes

I ran `poetry run poe test_unit` but did not ran the integration or smoke tests because of the requirement for a OPENAI_API_KEY and GRAPHRAG_API_KEY.

