### PR TITLE
Fix DRIFT search on Azure AI Search

### DIFF
--- a/.semversioner/next-release/patch-20250121205226363912.json
+++ b/.semversioner/next-release/patch-20250121205226363912.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Fix DRIFT search on Azure AI Search."
+}

--- a/graphrag/vector_stores/azure_ai_search.py
+++ b/graphrag/vector_stores/azure_ai_search.py
@@ -111,7 +111,7 @@ class AzureAISearchVectorStore(BaseVectorStore):
                         name="vector",
                         type=SearchFieldDataType.Collection(SearchFieldDataType.Single),
                         searchable=True,
-                        hidden=False, # DRIFT needs to return the vector for client-side similarity
+                        hidden=False,  # DRIFT needs to return the vector for client-side similarity
                         vector_search_dimensions=self.vector_size,
                         vector_search_profile_name=self.vector_search_profile_name,
                     ),

--- a/graphrag/vector_stores/azure_ai_search.py
+++ b/graphrag/vector_stores/azure_ai_search.py
@@ -111,6 +111,7 @@ class AzureAISearchVectorStore(BaseVectorStore):
                         name="vector",
                         type=SearchFieldDataType.Collection(SearchFieldDataType.Single),
                         searchable=True,
+                        hidden=False, # DRIFT needs to return the vector for client-side similarity
                         vector_search_dimensions=self.vector_size,
                         vector_search_profile_name=self.vector_search_profile_name,
                     ),

--- a/tests/fixtures/min-csv/config.json
+++ b/tests/fixtures/min-csv/config.json
@@ -134,6 +134,14 @@
         {
             "query": "What is the major conflict in this story and who are the protagonist and antagonist?",
             "method": "global"
+        },
+        {
+            "query": "What is Dulce Base?",
+            "method": "drift"
+        },
+        {
+            "query": "Who is Jordan Hayes?",
+            "method": "basic"
         }
     ],
     "slow": false

--- a/tests/fixtures/min-csv/config.json
+++ b/tests/fixtures/min-csv/config.json
@@ -136,10 +136,6 @@
             "method": "global"
         },
         {
-            "query": "What is Dulce Base?",
-            "method": "drift"
-        },
-        {
             "query": "Who is Jordan Hayes?",
             "method": "basic"
         }

--- a/tests/fixtures/text/config.json
+++ b/tests/fixtures/text/config.json
@@ -152,6 +152,14 @@
         {
             "query": "What is the major conflict in this story and who are the protagonist and antagonist?",
             "method": "global"
+        },
+        {
+            "query": "What is Dulce Base?",
+            "method": "drift"
+        },
+        {
+            "query": "Who is Jordan Hayes?",
+            "method": "basic"
         }
     ],
     "slow": false

--- a/tests/fixtures/text/config.json
+++ b/tests/fixtures/text/config.json
@@ -154,10 +154,6 @@
             "method": "global"
         },
         {
-            "query": "What is Dulce Base?",
-            "method": "drift"
-        },
-        {
             "query": "Who is Jordan Hayes?",
             "method": "basic"
         }


### PR DESCRIPTION
AZAIS embeddings were not including the vector itself in the list of retrievable fields, which DRIFT relies on for local cosine similarity checks.

This also adds DRIFT and Basic search queries to the smoke tests, so we should catch search issues more reliably with AZAIS and lancedb.