### PR TITLE
Fix recursive report generation

### DIFF
--- a/.semversioner/next-release/patch-20250130182248267480.json
+++ b/.semversioner/next-release/patch-20250130182248267480.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Fix report generation recursion."
+}

--- a/graphrag/index/operations/summarize_communities/community_reports_extractor/prep_community_report_context.py
+++ b/graphrag/index/operations/summarize_communities/community_reports_extractor/prep_community_report_context.py
@@ -30,6 +30,7 @@ log = logging.getLogger(__name__)
 
 
 def prep_community_report_context(
+    report_df: pd.DataFrame | None,
     community_hierarchy_df: pd.DataFrame,
     local_context_df: pd.DataFrame,
     level: int,
@@ -42,8 +43,6 @@ def prep_community_report_context(
     - Check if local context fits within the limit, if yes use local context
     - If local context exceeds the limit, iteratively replace local context with sub-community reports, starting from the biggest sub-community
     """
-    report_df = pd.DataFrame()
-
     # Filter by community level
     level_context_df = local_context_df.loc[
         local_context_df.loc[:, schemas.COMMUNITY_LEVEL] == level
@@ -62,7 +61,7 @@ def prep_community_report_context(
     if invalid_context_df.empty:
         return valid_context_df
 
-    if report_df.empty:
+    if report_df is None or report_df.empty:
         invalid_context_df.loc[:, schemas.CONTEXT_STRING] = _sort_and_trim_context(
             invalid_context_df, max_tokens
         )

--- a/graphrag/index/operations/summarize_communities_text/context_builder.py
+++ b/graphrag/index/operations/summarize_communities_text/context_builder.py
@@ -76,10 +76,10 @@ def prep_local_context(
 
 
 def prep_community_report_context(
-    local_context_df: pd.DataFrame,
+    report_df: pd.DataFrame | None,
     community_hierarchy_df: pd.DataFrame,
+    local_context_df: pd.DataFrame,
     level: int,
-    report_df: pd.DataFrame | None = None,
     max_tokens: int = 16000,
 ) -> pd.DataFrame:
     """


### PR DESCRIPTION
When adding FastGraphRAG I inadvertently removed the report recursion, which could result in very large report contexts being trimmed instead of rolled up. The PR restores the recursion.