### PR TITLE
Add run_count to smoke tests

### DIFF
--- a/.github/workflows/python-smoke-tests.yml
+++ b/.github/workflows/python-smoke-tests.yml
@@ -118,4 +118,4 @@ jobs:
         if: always()
         with:
           name: smoke-test-artifacts-${{ matrix.python-version }}-${{ matrix.poetry-version }}-${{ runner.os }}
-          path: tests/fixtures/*/output
+          path: tests/fixtures/*

--- a/tests/fixtures/text/config.json
+++ b/tests/fixtures/text/config.json
@@ -117,5 +117,6 @@
             "method": "basic"
         }
     ],
-    "slow": false
+    "slow": false,
+    "run_count": 2
 }

--- a/tests/smoke/test_fixtures.py
+++ b/tests/smoke/test_fixtures.py
@@ -261,6 +261,7 @@ class TestIndexer:
         input_file_type: str,
         workflow_config: dict[str, dict[str, Any]],
         query_config: list[dict[str, str]],
+        run_count: int = 1,
     ):
         if workflow_config.get("skip"):
             print(f"skipping smoke test {input_path})")
@@ -273,7 +274,11 @@ class TestIndexer:
             dispose = asyncio.run(prepare_azurite_data(input_path, azure))
 
         print("running indexer")
-        self.__run_indexer(root, input_file_type)
+        # run the indexer more than once if requested - subsequent runs should use the cache
+        # this verifies that cache behavior is stable
+        for i in range(run_count):
+            print(f"run {i + 1} of {run_count}")
+            self.__run_indexer(root, input_file_type)
         print("indexer complete")
 
         if dispose is not None:

--- a/tests/smoke/test_fixtures.py
+++ b/tests/smoke/test_fixtures.py
@@ -273,13 +273,13 @@ class TestIndexer:
         if azure is not None:
             dispose = asyncio.run(prepare_azurite_data(input_path, azure))
 
-        print("running indexer")
+        log.info("running indexer")
         # run the indexer more than once if requested - subsequent runs should use the cache
         # this verifies that cache behavior is stable
         for i in range(run_count):
-            print(f"run {i + 1} of {run_count}")
+            log.info(f"run {i + 1} of {run_count}")  # noqa: G004
             self.__run_indexer(root, input_file_type)
-        print("indexer complete")
+        log.info("indexer complete")
 
         if dispose is not None:
             dispose()


### PR DESCRIPTION
Adds a run count so we can loop the indexing - runs after the first should use the cache, so we can test stability