### PR TITLE
Add ability to provide a custom credential in AzureAISearchVectorStore

### DIFF
--- a/graphrag/vector_stores/azure_ai_search.py
+++ b/graphrag/vector_stores/azure_ai_search.py
@@ -47,6 +47,7 @@ class AzureAISearchVectorStore(BaseVectorStore):
         api_key = kwargs.get("api_key")
         audience = kwargs.get("audience")
         self.vector_size = kwargs.get("vector_size", DEFAULT_VECTOR_SIZE)
+        provided_credential = kwargs.get("credential")
 
         self.vector_search_profile_name = kwargs.get(
             "vector_search_profile_name", "vectorSearchProfile"
@@ -54,19 +55,17 @@ class AzureAISearchVectorStore(BaseVectorStore):
 
         if url:
             audience_arg = {"audience": audience} if audience and not api_key else {}
+            credential = AzureKeyCredential(api_key) if api_key else (provided_credential if provided_credential else DefaultAzureCredential())
+
             self.db_connection = SearchClient(
                 endpoint=url,
                 index_name=self.collection_name,
-                credential=(
-                    AzureKeyCredential(api_key) if api_key else DefaultAzureCredential()
-                ),
+                credential=credential,
                 **audience_arg,
             )
             self.index_client = SearchIndexClient(
                 endpoint=url,
-                credential=(
-                    AzureKeyCredential(api_key) if api_key else DefaultAzureCredential()
-                ),
+                credential=credential,
                 **audience_arg,
             )
         else:


### PR DESCRIPTION

## Description

My team is using GraphRAG's AzureAISearchVectorStore class. Where we're using this, we need the ability to provide a credential directly, as we can't set `api_key` and `DefaultAzureCredential` doesn't meet our needs.

By default, AzureAISearchVectorStore class will:
* check for an `api_key` to be set
* if no `api_key` is provided, default to `DefaultAzureCredential`


Our proposed change will add the support in this way:
* check for an `api_key` to be set
* if no `api_key` is provided, use a provided `credential` if one is given.
* if no other input is provided, default to `DefaultAzureCredential`

## Related Issues

#1695 

## Proposed Changes

Our proposed change will add the support in this way:
* check for an `api_key` to be set
* if no `api_key` is provided, use a provided `credential` if one is given.
* if no other input is provided, default to `DefaultAzureCredential`

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes

This probably won't solve use cases through the API, but it should enable future expansion if needed
