### PR TITLE
Fix cache sweep method implementation - Fixes #1833

### DIFF
--- a/graphrag/language_model/providers/fnllm/cache.py
+++ b/graphrag/language_model/providers/fnllm/cache.py
@@ -42,3 +42,7 @@ class FNLLMCacheProvider(FNLLMCache):
         """Create a child cache."""
         child_cache = self._cache.child(key)
         return FNLLMCacheProvider(child_cache)
+
+    async def sweep(self) -> None:
+        """Clear expired or unnecessary cache entries."""
+        await self._cache.sweep()


### PR DESCRIPTION
Fixes #1833

Add the `sweep` method to `FNLLMCacheProvider` class to clear expired or unnecessary cache entries.

* Implement the `sweep` method to call the parent sweep method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/graphrag/pull/1834?shareId=e78d7cfb-057e-4c15-8c97-1842a032260c).