### PR TITLE
fix: Use format() for community report prompt

### DIFF
--- a/graphrag/index/operations/summarize_communities/community_reports_extractor.py
+++ b/graphrag/index/operations/summarize_communities/community_reports_extractor.py
@@ -74,9 +74,9 @@ class CommunityReportsExtractor:
         output = None
         try:
             input_text = inputs[self._input_text_key]
-            prompt = self._extraction_prompt.replace(
-                "{" + self._input_text_key + "}", input_text
-            )
+            prompt = self._extraction_prompt.format(**{
+                self._input_text_key: input_text
+            })
             response = await self._model.achat(
                 prompt,
                 json=True,  # Leaving this as True to avoid creating new cache entries


### PR DESCRIPTION
<!--
Thanks for contributing to GraphRAG!

Please do not make *Draft* pull requests, as they still notify anyone watching the repo.

Create a pull request when it is ready for review and feedback.

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

## Description

This pull request addresses two key issues in the `CommunityReportsExtractor` related to prompt formatting:

1.  **Incorrect Handling of Escaped Braces:** The previous implementation used `replace()` to inject the input text into the prompt. However, the prompt template contains escaped curly braces (`{{` and `}}`) that are intended to be treated as literal characters, not as placeholders for substitution. `replace()` does not handle these escaped braces correctly, leading to malformed prompts.
https://github.com/microsoft/graphrag/blob/b7b2b562cea7893369442a7de07032360d7cd6c3/graphrag/prompts/index/community_report.py#L22-L37
3.  **Inconsistency:** Other parts of the codebase use the `.format()` method for prompt construction. The `CommunityReportsExtractor` was an outlier, using `replace()` instead. This inconsistency made the code harder to understand and maintain.

This PR resolves these issues by switching from `replace()` to `.format()` for prompt construction.


## Related Issues

[Reference any related issues or tasks that this pull request addresses.]

## Proposed Changes

-   Modified the `__call__` method in `CommunityReportsExtractor` to use `.format()` instead of `.replace()` when constructing the prompt.
-   The prompt now correctly handles escaped curly braces (`{{` and `}}`) within the template.
-   The prompt now uses the format method to inject the input text into the prompt.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes

[Add any additional notes or context that may be helpful for the reviewer(s).]
