### PR TITLE
Optional embeddings

### DIFF
--- a/.semversioner/next-release/patch-20250422232634719243.json
+++ b/.semversioner/next-release/patch-20250422232634719243.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Align embeddings table loading with configured fields."
+}


### PR DESCRIPTION
Makes all tables optional in the embeddings workflow, so that if tables are missing (e.g., due to intentional partial workflows) they only fail if an embedded field from that table is expected.