### PR TITLE
Fix: Replace manual placeholders to avoid .format() issues in COMMUNITY_REPORT_PROMPT

### DIFF
--- a/graphrag/index/operations/summarize_communities/community_reports_extractor.py
+++ b/graphrag/index/operations/summarize_communities/community_reports_extractor.py
@@ -73,10 +73,11 @@ class CommunityReportsExtractor:
         """Call method definition."""
         output = None
         try:
-            prompt = self._extraction_prompt.format(**{
-                INPUT_TEXT_KEY: input_text,
-                MAX_LENGTH_KEY: str(self._max_report_length),
-            })
+            prompt = self._extraction_prompt.replace(
+                "{" + INPUT_TEXT_KEY + "}", input_text
+            ).replace(
+                "{" + MAX_LENGTH_KEY + "}", str(self._max_report_length)
+            )
             response = await self._model.achat(
                 prompt,
                 json=True,  # Leaving this as True to avoid creating new cache entries


### PR DESCRIPTION

<!--
Thanks for contributing to GraphRAG!

Please do not make *Draft* pull requests, as they still notify anyone watching the repo.

Create a pull request when it is ready for review and feedback.

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

## Description

- In the `community_reports_extractor` file Using .format() caused errors because the COMMUNITY_REPORT_PROMPT has other `{}` braces (e.g., in JSON examples).
- Python .format() tries to parse those and fails.

## Related Issues

#1900 

## Proposed Changes

- Switched to using .replace() to manually substitute `{input_text}` and `{max_report_length}`.
- Avoids conflict with embedded braces and ensures prompt generation works correctly.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes

- The error occurred because .format() was used on a prompt where only the input variables ({input_text} and {max_report_length}) were meant to be replaced.
- Although all non-input curly braces (for JSON structure) were correctly escaped with double brackets {{ }}, using .format() still caused issues due to complex formatting.
- Replaced .format() with manual .replace() for input_text and max_report_length to fix the problem safely without impacting the rest of the prompt structure.
