### PR TITLE
Fix missing function parameter in search.py

### DIFF
--- a/graphrag/query/structured_search/global_search/search.py
+++ b/graphrag/query/structured_search/global_search/search.py
@@ -371,7 +371,7 @@ class GlobalSearch(BaseSearch[GlobalContextBuilder]):
             text_data = "\n\n".join(data)
 
             search_prompt = self.reduce_system_prompt.format(
-                report_data=text_data, response_type=self.response_type
+                report_data=text_data, response_type=self.response_type, max_length=self.reduce_max_length
             )
             if self.allow_general_knowledge:
                 search_prompt += "\n" + self.general_knowledge_inclusion_prompt


### PR DESCRIPTION
## Description

This PR fixes a bug in the `_reduce_response` function in the `search.py` file in global_search. 

A format call is made on the `self.reduce_system_prompt` string which contains a placeholder for `max_length` which is not provided in the format call.

## Proposed Changes

Add the missing parameter to the function call.

## Checklist

- [ x ] I have tested these changes locally.
- [ x ] I have reviewed the code changes.
- [ x ] I have updated the documentation (if necessary).
- [ x ] I have added appropriate unit tests (if applicable).