### PR TITLE
Fix prompt tuning sampling error when LIMIT is greater than number of…

### DIFF
--- a/graphrag/prompt_tune/loader/input.py
+++ b/graphrag/prompt_tune/loader/input.py
@@ -67,8 +67,8 @@ async def load_docs_in_chunks(
 
     # Depending on the select method, build the dataset
     if limit <= 0 or limit > len(chunks_df):
-        logger.warning(f"Limit out of range, using default number of chunks: {LIMIT}")  # noqa: G004
-        limit = LIMIT
+        limit = min(LIMIT, len(chunks_df))
+        logger.warning(f"Limit out of range, using default number of chunks: {limit}")  # noqa: G004
 
     if select_method == DocSelectionType.TOP:
         chunks_df = chunks_df[:limit]


### PR DESCRIPTION
## Description

Prompt tuning errors out when the number of chunks is less than the default LIMIT, saying
"Auto-prompt generation failed: Cannot take a larger sample than population when 'replace=False'"

## Proposed Changes

This patch sets the limit to the min of LIMIT and the number of chunks.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).
