### PR TITLE
feat: Make community summarization rate limit configurable

### DIFF
--- a/graphrag/index/operations/summarize_communities/strategies.py
+++ b/graphrag/index/operations/summarize_communities/strategies.py
@@ -52,7 +52,10 @@ async def _run_extractor(
     args: StrategyConfig,
 ) -> CommunityReport | None:
     # RateLimiter
-    rate_limiter = RateLimiter(rate=1, per=60)
+    # Read rate and per from the config, defaulting to 1 per 60 if not provided
+    rate = args.get("rate", 1)
+    per = args.get("per", 60)
+    rate_limiter = RateLimiter(rate=rate, per=per)
     extractor = CommunityReportsExtractor(
         model,
         extraction_prompt=args.get("extraction_prompt", None),


### PR DESCRIPTION
## Description

Currently , the community summarization step is hard-coded to run only one request every 60 seconds. This makes the indexing process extremely slow if you have a lot of communities to summarize.

This PR fixes this by letting users configure the rate limit themselves in the YAML config, so they can speed it up to match what their LLM's API can handle.

## Related Issues

Fixes #2020

## Proposed Changes

- In `graphrag/index/operations/summarize_communities/strategies.py`, the `rate` and `per` values for the `RateLimiter` are now pulled from the strategy `args`.
- The old hard-coded values (`rate=1, per=60`) are now used as defaults, so existing configs won't break.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes

To use the new settings, you can add `rate` and `per` to your config file under a strategy that uses it. Here's an example for the summarization step:

```yaml
summarize_communities:
  strategy:
    type: graph_intelligence
    rate: 30 # e.g., 30 requests
    per: 60  # e.g., per 60 seconds