### PR TITLE
chore(types): add return type hint to gen_sha512_hash

### DIFF
--- a/graphrag/index/utils/hashing.py
+++ b/graphrag/index/utils/hashing.py
@@ -8,7 +8,7 @@ from hashlib import sha512
 from typing import Any
 
 
-def gen_sha512_hash(item: dict[str, Any], hashcode: Iterable[str]):
+def gen_sha512_hash(item: dict[str, Any], hashcode: Iterable[str]) -> str:
     """Generate a SHA512 hash."""
     hashed = "".join([str(item[column]) for column in hashcode])
     return f"{sha512(hashed.encode('utf-8'), usedforsecurity=False).hexdigest()}"


### PR DESCRIPTION
## Description

Added a missing return type hint (-> str) to the gen_sha512_hash function to improve type safety and readability.

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).
