### PR TITLE
Fix type mismatch in DynamicCommunitySelection children lookup

### DIFF
--- a/.semversioner/next-release/patch-20251110004953346654.json
+++ b/.semversioner/next-release/patch-20251110004953346654.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Fix type mismatch in DynamicCommunitySelection when checking children communities. Convert child IDs to string to match self.reports key type (fixes #2004)"
+}

--- a/graphrag/query/context_builder/dynamic_community_selection.py
+++ b/graphrag/query/context_builder/dynamic_community_selection.py
@@ -123,8 +123,10 @@ class DynamicCommunitySelection:
                     # TODO check why some sub_communities are NOT in report_df
                     if community in self.communities:
                         for child in self.communities[community].children:
-                            if child in self.reports:
-                                communities_to_rate.append(child)
+                            # Convert child to string to match self.reports key type
+                            child_str = str(child)
+                            if child_str in self.reports:
+                                communities_to_rate.append(child_str)
                             else:
                                 logger.debug(
                                     "dynamic community selection: cannot find community %s in reports",


### PR DESCRIPTION
 ## Description

  Fixes a type mismatch bug in `DynamicCommunitySelection` that prevented the algorithm from correctly traversing child communities during global search queries with `dynamic_community_selection=True`.

  ## Related Issues

  Fixes #2004

  ## Proposed Changes

  - **Fixed type mismatch in `dynamic_community_selection.py` (lines 125-129)**
    - Child community IDs from `self.communities[community].children` were not matching keys in `self.reports` dictionary due to type inconsistency
    - Added explicit string conversion (`str(child)`) to ensure child IDs match the `self.reports` key type
    - Added explanatory comment for clarity

  **Root Cause:**
  - `Community.children` contains IDs that may be loaded as integers
  - `CommunityReport.community_id` is defined as `str` type
  - `self.reports` dictionary is keyed by `community_id` (strings)
  - The membership test `if child in self.reports` always failed, causing all child communities to be skipped

  **Impact:**
  - Before fix: Only 10 out of 5,586 communities were referenced (stuck at level 0)
  - After fix: 309 out of 5,586 communities are correctly traversed across multiple levels

  ## Checklist

  - [v] I have tested these changes locally (unit tests pass)
  - [v] I have reviewed the code changes
  - [v] I have updated the documentation (added inline comment explaining the fix)
  - [v] I have added a semversioner changeset (patch level)