### PR TITLE
feat: Add Neo4j + GraphQL POC integration

### DIFF
--- a/graphrag/docs/experimental/neo4j_graphql_poc.md
+++ b/graphrag/docs/experimental/neo4j_graphql_poc.md
@@ -1,0 +1,196 @@
+# Neo4j and GraphQL Integration (Experimental POC)
+
+## Overview
+
+This is a **minimal proof of concept** (POC) to explore replacing 1-2 dataframe-based READ operations during query time with Neo4j-backed reads, and expose a read-only GraphQL query interface.
+
+**Status**: Experimental / POC - Not for production use
+
+## Scope
+
+### What Was Changed
+
+This POC makes **minimal, targeted changes** to exactly **two workflow steps**:
+
+1. **Entity lookup by name** (`graphrag/query/context_builder/entity_extraction.py`)
+   - When entities are looked up by name during query execution, Neo4j is attempted first
+   - Falls back to existing dataframe logic if Neo4j is unavailable
+
+2. **Entity→Document relationship lookup** (`graphrag/query/input/retrieval/text_units.py`)
+   - When finding documents/text units that mention an entity, Neo4j is attempted first
+   - Falls back to existing dataframe logic if Neo4j is unavailable
+
+### What Was NOT Changed
+
+- ❌ Indexing logic remains unchanged (still writes to parquet files)
+- ❌ Embedding logic remains unchanged
+- ❌ All WRITE operations remain dataframe-based
+- ❌ Defaults and prompts are unchanged
+- ❌ Settings.yaml behavior is unchanged
+- ❌ No other query operations were modified
+
+## Architecture
+
+### Neo4j Data Model
+
+The POC uses a minimal schema with only three node/relationship types:
+
+```cypher
+(:Entity {id, name, type})
+(:Document {id, title, source})
+(:Document)-[:MENTIONS]->(:Entity)
+```
+
+**No additional nodes, relationships, or properties are used.**
+
+### Feature Flag
+
+Neo4j usage is controlled by environment variable:
+
+```bash
+GRAPHRAG_USE_NEO4J=true
+```
+
+When disabled (default), all operations use existing dataframe logic.
+
+### Neo4j Connection
+
+Neo4j connection details are read from environment variables:
+
+- `NEO4J_URI` - Neo4j connection URI (e.g., `bolt://localhost:7687`)
+- `NEO4J_USER` - Neo4j username
+- `NEO4J_PASSWORD` - Neo4j password
+
+If connection fails or Neo4j is unavailable, the system gracefully falls back to dataframe reads.
+
+## GraphQL API
+
+A minimal GraphQL schema is provided with **ONE read-only query**:
+
+### Schema
+
+```graphql
+type Query {
+  entity(name: String!): Entity
+}
+
+type Entity {
+  id: String
+  name: String
+  type: String
+  documents: [Document]
+}
+
+type Document {
+  id: String
+  title: String
+  source: String
+}
+```
+
+### Example Query
+
+```graphql
+query {
+  entity(name: "Microsoft") {
+    id
+    name
+    type
+    documents {
+      id
+      title
+      source
+    }
+  }
+}
+```
+
+### Running the GraphQL Server
+
+```python
+from graphrag.graph.graphql_server import run_graphql_server
+
+# Start server on default port 5000
+run_graphql_server()
+
+# Or customize host/port
+run_graphql_server(host="0.0.0.0", port=8080)
+```
+
+Then access at `http://localhost:5000/graphql`:
+
+```bash
+curl -X POST http://localhost:5000/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "query { entity(name: \"Microsoft\") { name documents { title } } }"}'
+```
+
+## Setup
+
+### Prerequisites
+
+1. **Neo4j Database**: A running Neo4j instance with the required schema
+2. **Python Dependencies** (optional - only if using GraphQL):
+   ```bash
+   pip install neo4j ariadne flask
+   ```
+
+### Environment Configuration
+
+Add to your `.env` file or environment:
+
+```bash
+# Enable Neo4j (disabled by default)
+GRAPHRAG_USE_NEO4J=true
+
+# Neo4j connection details
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=your_password
+```
+
+## Data Population
+
+**Important**: This POC does NOT automatically populate Neo4j with data. You must manually populate Neo4j with entities and documents using the schema above.
+
+Example Cypher for populating data:
+
+```cypher
+// Create an entity
+CREATE (e:Entity {id: "entity-1", name: "Microsoft", type: "organization"})
+
+// Create a document
+CREATE (d:Document {id: "doc-1", title: "Microsoft Research", source: "example.txt"})
+
+// Create relationship
+MATCH (d:Document {id: "doc-1"}), (e:Entity {name: "Microsoft"})
+CREATE (d)-[:MENTIONS]->(e)
+```
+
+## Code Locations
+
+- **Neo4j Client**: `graphrag/graph/neo4j_client.py`
+- **GraphQL Schema**: `graphrag/graph/graphql_schema.py`
+- **GraphQL Server**: `graphrag/graph/graphql_server.py`
+- **Modified Query Logic**: 
+  - `graphrag/query/context_builder/entity_extraction.py` (entity lookup)
+  - `graphrag/query/input/retrieval/text_units.py` (document lookup)
+
+## Limitations and Considerations
+
+1. **Read-only**: Only READ operations are replaced. All WRITE operations remain unchanged.
+2. **Minimal scope**: Only 2 specific workflow steps are modified
+3. **Fallback logic**: If Neo4j fails, dataframe logic is used automatically
+4. **No data migration**: Neo4j must be populated separately
+5. **Experimental**: This is a POC for exploration, not production-ready code
+
+## Future Work
+
+If this POC proves valuable, potential next steps could include:
+- Automatic data population from indexing outputs
+- Additional query operations
+- Performance optimization
+- Production hardening
+
+However, this POC intentionally remains minimal to assess feasibility without extensive changes to the codebase.
+

--- a/graphrag/graphrag/graph/__init__.py
+++ b/graphrag/graphrag/graph/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""Graph database integration for GraphRAG (experimental POC)."""
+

--- a/graphrag/graphrag/graph/graphql_schema.py
+++ b/graphrag/graphrag/graph/graphql_schema.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""
+Experimental GraphQL schema for GraphRAG Neo4j integration.
+
+This is a minimal proof of concept that exposes ONE read-only query for
+accessing entity information from Neo4j. No mutations are included.
+"""
+
+from typing import Any
+
+# Try to import GraphQL libraries, but make it optional
+try:
+    from ariadne import QueryType, make_executable_schema, gql
+    GRAPHQL_AVAILABLE = True
+except ImportError:
+    GRAPHQL_AVAILABLE = False
+    # Define minimal types for type checking when GraphQL is unavailable
+    QueryType = Any
+    make_executable_schema = Any
+    gql = Any
+
+
+# GraphQL type definitions
+TYPE_DEFS = """
+    type Query {
+        entity(name: String!): Entity
+    }
+    
+    type Entity {
+        id: String
+        name: String
+        type: String
+        documents: [Document]
+    }
+    
+    type Document {
+        id: String
+        title: String
+        source: String
+    }
+"""
+
+
+def _create_resolvers():
+    """Create GraphQL resolvers."""
+    from ariadne import ObjectType
+    
+    query = QueryType()
+    entity_type = ObjectType("Entity")
+    
+    @query.field("entity")
+    def resolve_entity(_, info, name: str) -> dict[str, Any] | None:
+        """
+        EXPERIMENTAL POC: Resolve entity query from Neo4j.
+        
+        Parameters
+        ----------
+        name : str
+            Entity name to lookup
+            
+        Returns
+        -------
+        dict | None
+            Entity data if found, None otherwise
+        """
+        try:
+            from graphrag.graph.neo4j_client import get_entity_by_name_neo4j
+            
+            entity = get_entity_by_name_neo4j(name)
+            return entity
+        except Exception:
+            return None
+    
+    @entity_type.field("documents")
+    def resolve_entity_documents(entity: dict[str, Any], _) -> list[dict[str, Any]]:
+        """
+        EXPERIMENTAL POC: Resolve documents for an entity.
+        
+        Fetches documents mentioning this entity from Neo4j.
+        """
+        try:
+            from graphrag.graph.neo4j_client import get_documents_by_entity_neo4j
+            entity_name = entity.get("name")
+            if entity_name:
+                return get_documents_by_entity_neo4j(entity_name)
+        except Exception:
+            pass
+        
+        return []
+    
+    return query, entity_type
+
+
+def create_schema():
+    """
+    Create executable GraphQL schema.
+    
+    Returns
+    -------
+    GraphQLSchema | None
+        Executable schema if GraphQL libraries are available, None otherwise
+    """
+    if not GRAPHQL_AVAILABLE:
+        return None
+    
+    query, entity_type = _create_resolvers()
+    schema = make_executable_schema(gql(TYPE_DEFS), query, entity_type)
+    return schema
+

--- a/graphrag/graphrag/graph/graphql_server.py
+++ b/graphrag/graphrag/graph/graphql_server.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""
+Experimental GraphQL server for GraphRAG Neo4j integration.
+
+This provides a simple HTTP endpoint to execute GraphQL queries against
+Neo4j data. Only READ operations are supported.
+"""
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Try to import required libraries
+try:
+    from ariadne import graphql_sync, format_error
+    from flask import Flask, request, jsonify
+    SERVER_AVAILABLE = True
+except ImportError:
+    SERVER_AVAILABLE = False
+    Flask = Any
+    graphql_sync = Any
+    format_error = Any
+
+
+def create_graphql_app():
+    """
+    Create Flask app with GraphQL endpoint.
+    
+    EXPERIMENTAL POC: This creates a minimal GraphQL server that exposes
+    read-only queries against Neo4j. The endpoint is /graphql.
+    
+    Returns
+    -------
+    Flask | None
+        Flask app if libraries are available, None otherwise
+    """
+    if not SERVER_AVAILABLE:
+        logger.warning(
+            "GraphQL server dependencies not available. "
+            "Install with: pip install ariadne flask"
+        )
+        return None
+    
+    from graphrag.graph.graphql_schema import create_schema
+    
+    schema = create_schema()
+    if schema is None:
+        return None
+    
+    app = Flask(__name__)
+    
+    @app.route("/graphql", methods=["POST"])
+    def graphql_server():
+        """
+        GraphQL endpoint.
+        
+        Accepts POST requests with JSON body:
+        {
+            "query": "query { entity(name: \"EntityName\") { name documents { title } } }"
+        }
+        """
+        try:
+            data = request.get_json()
+            query = data.get("query")
+            variables = data.get("variables", {})
+            
+            if not query:
+                return jsonify({"error": "Query is required"}), 400
+            
+            success, result = graphql_sync(
+                schema,
+                {"query": query, "variables": variables},
+                debug=True
+            )
+            
+            status_code = 200 if success else 400
+            return jsonify(result), status_code
+            
+        except Exception as e:
+            logger.exception("Error executing GraphQL query")
+            return jsonify({"error": str(e)}), 500
+    
+    @app.route("/health", methods=["GET"])
+    def health():
+        """Health check endpoint."""
+        return jsonify({"status": "ok", "experimental": "neo4j-graphql-poc"})
+    
+    return app
+
+
+def run_graphql_server(host: str = "127.0.0.1", port: int = 5000, debug: bool = False):
+    """
+    Run the GraphQL server.
+    
+    EXPERIMENTAL POC: Starts a Flask server with GraphQL endpoint.
+    
+    Parameters
+    ----------
+    host : str
+        Host to bind to (default: 127.0.0.1)
+    port : int
+        Port to bind to (default: 5000)
+    debug : bool
+        Enable debug mode (default: False)
+    """
+    app = create_graphql_app()
+    if app is None:
+        logger.error("Cannot start GraphQL server: dependencies not available")
+        return
+    
+    logger.info(f"Starting experimental GraphQL server on {host}:{port}")
+    logger.warning(
+        "This is an experimental POC. Do not use in production."
+    )
+    app.run(host=host, port=port, debug=debug)
+

--- a/graphrag/graphrag/graph/neo4j_client.py
+++ b/graphrag/graphrag/graph/neo4j_client.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""
+Experimental Neo4j client for GraphRAG.
+
+This is a minimal proof of concept to replace 1-2 dataframe-based READ operations
+during query time with Neo4j-backed reads. All Neo4j logic is optional and falls
+back to existing dataframe logic if Neo4j is unavailable or disabled.
+"""
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Try to import Neo4j driver, but make it optional
+try:
+    from neo4j import GraphDatabase
+    NEO4J_AVAILABLE = True
+except ImportError:
+    NEO4J_AVAILABLE = False
+    logger.warning(
+        "Neo4j driver not available. Install with: pip install neo4j"
+    )
+
+
+def _is_neo4j_enabled() -> bool:
+    """Check if Neo4j is enabled via environment variable."""
+    return os.getenv("GRAPHRAG_USE_NEO4J", "false").lower() == "true"
+
+
+def _get_neo4j_connection():
+    """Get Neo4j database connection."""
+    if not NEO4J_AVAILABLE or not _is_neo4j_enabled():
+        return None
+    
+    uri = os.getenv("NEO4J_URI")
+    user = os.getenv("NEO4J_USER")
+    password = os.getenv("NEO4J_PASSWORD")
+    
+    if not all([uri, user, password]):
+        logger.warning(
+            "Neo4j is enabled but connection details are missing. "
+            "Set NEO4J_URI, NEO4J_USER, and NEO4J_PASSWORD environment variables."
+        )
+        return None
+    
+    try:
+        driver = GraphDatabase.driver(uri, auth=(user, password))
+        # Test connection
+        driver.verify_connectivity()
+        return driver
+    except Exception as e:
+        logger.warning(f"Failed to connect to Neo4j: {e}. Falling back to dataframe reads.")
+        return None
+
+
+def get_entity_by_name_neo4j(entity_name: str) -> dict[str, Any] | None:
+    """
+    EXPERIMENTAL: Get entity by name from Neo4j.
+    
+    Falls back to None if Neo4j is unavailable, allowing caller to use dataframe logic.
+    
+    Parameters
+    ----------
+    entity_name : str
+        Name of the entity to lookup
+        
+    Returns
+    -------
+    dict | None
+        Entity data as dict with keys: id, name, type
+        Returns None if Neo4j is unavailable or entity not found
+    """
+    driver = _get_neo4j_connection()
+    if driver is None:
+        return None
+    
+    try:
+        with driver.session() as session:
+            result = session.run(
+                "MATCH (e:Entity {name: $name}) RETURN e.id as id, e.name as name, e.type as type LIMIT 1",
+                name=entity_name
+            )
+            record = result.single()
+            if record:
+                return {
+                    "id": record["id"],
+                    "name": record["name"],
+                    "type": record["type"]
+                }
+            return None
+    except Exception as e:
+        logger.warning(f"Error querying Neo4j for entity {entity_name}: {e}")
+        return None
+    finally:
+        if driver is not None:
+            driver.close()
+
+
+def get_documents_by_entity_neo4j(entity_name: str) -> list[dict[str, Any]]:
+    """
+    EXPERIMENTAL: Get documents that mention an entity from Neo4j.
+    
+    Falls back to empty list if Neo4j is unavailable, allowing caller to use dataframe logic.
+    
+    Parameters
+    ----------
+    entity_name : str
+        Name of the entity
+        
+    Returns
+    -------
+    list[dict]
+        List of document dicts with keys: id, title, source
+        Returns empty list if Neo4j is unavailable
+    """
+    driver = _get_neo4j_connection()
+    if driver is None:
+        return []
+    
+    try:
+        with driver.session() as session:
+            result = session.run(
+                "MATCH (d:Document)-[:MENTIONS]->(e:Entity {name: $name}) "
+                "RETURN d.id as id, d.title as title, d.source as source",
+                name=entity_name
+            )
+            documents = []
+            for record in result:
+                documents.append({
+                    "id": record["id"],
+                    "title": record["title"],
+                    "source": record.get("source", "")
+                })
+            return documents
+    except Exception as e:
+        logger.warning(f"Error querying Neo4j for documents mentioning {entity_name}: {e}")
+        return []
+    finally:
+        if driver is not None:
+            driver.close()
+

--- a/graphrag/graphrag/query/context_builder/entity_extraction.py
+++ b/graphrag/graphrag/query/context_builder/entity_extraction.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""Orchestration Context Builders."""
+
+from enum import Enum
+
+from graphrag.data_model.entity import Entity
+from graphrag.data_model.relationship import Relationship
+from graphrag.language_model.protocol.base import EmbeddingModel
+from graphrag.query.input.retrieval.entities import (
+    get_entity_by_id,
+    get_entity_by_key,
+    get_entity_by_name,
+)
+from graphrag.vector_stores.base import BaseVectorStore
+
+
+class EntityVectorStoreKey(str, Enum):
+    """Keys used as ids in the entity embedding vectorstores."""
+
+    ID = "id"
+    TITLE = "title"
+
+    @staticmethod
+    def from_string(value: str) -> "EntityVectorStoreKey":
+        """Convert string to EntityVectorStoreKey."""
+        if value == "id":
+            return EntityVectorStoreKey.ID
+        if value == "title":
+            return EntityVectorStoreKey.TITLE
+
+        msg = f"Invalid EntityVectorStoreKey: {value}"
+        raise ValueError(msg)
+
+
+def map_query_to_entities(
+    query: str,
+    text_embedding_vectorstore: BaseVectorStore,
+    text_embedder: EmbeddingModel,
+    all_entities_dict: dict[str, Entity],
+    embedding_vectorstore_key: str = EntityVectorStoreKey.ID,
+    include_entity_names: list[str] | None = None,
+    exclude_entity_names: list[str] | None = None,
+    k: int = 10,
+    oversample_scaler: int = 2,
+) -> list[Entity]:
+    """Extract entities that match a given query using semantic similarity of text embeddings of query and entity descriptions."""
+    if include_entity_names is None:
+        include_entity_names = []
+    if exclude_entity_names is None:
+        exclude_entity_names = []
+    all_entities = list(all_entities_dict.values())
+    matched_entities = []
+    if query != "":
+        # get entities with highest semantic similarity to query
+        # oversample to account for excluded entities
+        search_results = text_embedding_vectorstore.similarity_search_by_text(
+            text=query,
+            text_embedder=lambda t: text_embedder.embed(t),
+            k=k * oversample_scaler,
+        )
+        for result in search_results:
+            if embedding_vectorstore_key == EntityVectorStoreKey.ID and isinstance(
+                result.document.id, str
+            ):
+                matched = get_entity_by_id(all_entities_dict, result.document.id)
+            else:
+                matched = get_entity_by_key(
+                    entities=all_entities,
+                    key=embedding_vectorstore_key,
+                    value=result.document.id,
+                )
+            if matched:
+                matched_entities.append(matched)
+    else:
+        all_entities.sort(key=lambda x: x.rank if x.rank else 0, reverse=True)
+        matched_entities = all_entities[:k]
+
+    # filter out excluded entities
+    if exclude_entity_names:
+        matched_entities = [
+            entity
+            for entity in matched_entities
+            if entity.title not in exclude_entity_names
+        ]
+
+    # add entities in the include_entity list
+    # EXPERIMENTAL POC: Try Neo4j first for entity lookup, fall back to dataframe logic
+    included_entities = []
+    for entity_name in include_entity_names:
+        # Try Neo4j lookup first (experimental POC)
+        try:
+            from graphrag.graph.neo4j_client import get_entity_by_name_neo4j
+            
+            neo4j_entity = get_entity_by_name_neo4j(entity_name)
+            if neo4j_entity:
+                # Convert Neo4j result to Entity object for compatibility
+                # Create a minimal Entity object with required fields
+                entity = Entity(
+                    id=neo4j_entity.get("id", ""),
+                    title=neo4j_entity.get("name", entity_name),
+                    type=neo4j_entity.get("type")
+                )
+                included_entities.append(entity)
+                continue  # Skip dataframe lookup if Neo4j found the entity
+        except Exception:
+            # Fall back to dataframe logic on any error
+            pass
+        
+        # Fallback to existing dataframe-based lookup
+        included_entities.extend(get_entity_by_name(all_entities, entity_name))
+    return included_entities + matched_entities
+
+
+def find_nearest_neighbors_by_entity_rank(
+    entity_name: str,
+    all_entities: list[Entity],
+    all_relationships: list[Relationship],
+    exclude_entity_names: list[str] | None = None,
+    k: int | None = 10,
+) -> list[Entity]:
+    """Retrieve entities that have direct connections with the target entity, sorted by entity rank."""
+    if exclude_entity_names is None:
+        exclude_entity_names = []
+    entity_relationships = [
+        rel
+        for rel in all_relationships
+        if rel.source == entity_name or rel.target == entity_name
+    ]
+    source_entity_names = {rel.source for rel in entity_relationships}
+    target_entity_names = {rel.target for rel in entity_relationships}
+    related_entity_names = (source_entity_names.union(target_entity_names)).difference(
+        set(exclude_entity_names)
+    )
+    top_relations = [
+        entity for entity in all_entities if entity.title in related_entity_names
+    ]
+    top_relations.sort(key=lambda x: x.rank if x.rank else 0, reverse=True)
+    if k:
+        return top_relations[:k]
+    return top_relations

--- a/graphrag/graphrag/query/input/retrieval/text_units.py
+++ b/graphrag/graphrag/query/input/retrieval/text_units.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""Util functions to retrieve text units from a collection."""
+
+from typing import Any, cast
+
+import pandas as pd
+
+from graphrag.data_model.entity import Entity
+from graphrag.data_model.text_unit import TextUnit
+
+
+def _get_documents_by_entity_neo4j(entity_name: str) -> list[dict[str, Any]]:
+    """
+    EXPERIMENTAL POC: Get documents mentioning an entity from Neo4j.
+    
+    This is an internal helper that attempts to use Neo4j for entity→document
+    relationship lookup. Falls back to empty list if Neo4j is unavailable.
+    
+    Parameters
+    ----------
+    entity_name : str
+        Name of the entity
+        
+    Returns
+    -------
+    list[dict]
+        List of document dicts with keys: id, title, source
+        Returns empty list if Neo4j is unavailable
+    """
+    try:
+        from graphrag.graph.neo4j_client import get_documents_by_entity_neo4j as neo4j_func
+        return neo4j_func(entity_name)
+    except Exception:
+        return []
+
+
+def get_candidate_text_units(
+    selected_entities: list[Entity],
+    text_units: list[TextUnit],
+) -> pd.DataFrame:
+    """
+    Get all text units that are associated to selected entities.
+    
+    EXPERIMENTAL POC: If Neo4j is enabled and at least one entity is provided,
+    attempts to use Neo4j for entity→document relationship lookup for the first entity.
+    Falls back to existing dataframe-based logic if Neo4j is unavailable.
+    """
+    # EXPERIMENTAL POC: Try Neo4j for entity→document lookup if enabled
+    # Only use Neo4j for the first entity to keep the change minimal
+    if selected_entities:
+        first_entity = selected_entities[0]
+        if first_entity.title:
+            neo4j_docs = _get_documents_by_entity_neo4j(first_entity.title)
+            if neo4j_docs:
+                # Convert Neo4j documents to TextUnit-like objects
+                # For POC simplicity, create minimal TextUnit objects from Neo4j results
+                neo4j_text_units = []
+                for doc in neo4j_docs:
+                    # Create a TextUnit from Neo4j document data
+                    # Use document title as text for simplicity in POC
+                    text_unit = TextUnit(
+                        id=doc.get("id", ""),
+                        short_id=doc.get("id", ""),
+                        text=doc.get("title", doc.get("source", "")),
+                        document_ids=[doc.get("id", "")]
+                    )
+                    neo4j_text_units.append(text_unit)
+                
+                # Convert to dataframe
+                if neo4j_text_units:
+                    neo4j_df = to_text_unit_dataframe(neo4j_text_units)
+                    # For remaining entities, use dataframe logic and merge results
+                    if len(selected_entities) > 1:
+                        remaining_entities = selected_entities[1:]
+                        selected_text_ids = [
+                            entity.text_unit_ids 
+                            for entity in remaining_entities 
+                            if entity.text_unit_ids
+                        ]
+                        selected_text_ids = [item for sublist in selected_text_ids for item in sublist]
+                        selected_text_units = [
+                            unit for unit in text_units 
+                            if unit.id in selected_text_ids
+                        ]
+                        remaining_df = to_text_unit_dataframe(selected_text_units)
+                        # Merge dataframes
+                        return pd.concat([neo4j_df, remaining_df], ignore_index=True)
+                    return neo4j_df
+    
+    # Fallback to existing dataframe-based logic
+    selected_text_ids = [
+        entity.text_unit_ids for entity in selected_entities if entity.text_unit_ids
+    ]
+    selected_text_ids = [item for sublist in selected_text_ids for item in sublist]
+    selected_text_units = [unit for unit in text_units if unit.id in selected_text_ids]
+    return to_text_unit_dataframe(selected_text_units)
+
+
+def to_text_unit_dataframe(text_units: list[TextUnit]) -> pd.DataFrame:
+    """Convert a list of text units to a pandas dataframe."""
+    if len(text_units) == 0:
+        return pd.DataFrame()
+
+    # add header
+    header = ["id", "text"]
+    attribute_cols = (
+        list(text_units[0].attributes.keys()) if text_units[0].attributes else []
+    )
+    attribute_cols = [col for col in attribute_cols if col not in header]
+    header.extend(attribute_cols)
+
+    records = []
+    for unit in text_units:
+        new_record = [
+            unit.short_id,
+            unit.text,
+            *[
+                str(unit.attributes.get(field, ""))
+                if unit.attributes and unit.attributes.get(field)
+                else ""
+                for field in attribute_cols
+            ],
+        ]
+        records.append(new_record)
+    return pd.DataFrame(records, columns=cast("Any", header))


### PR DESCRIPTION
- Add Neo4j client with graceful fallback (EXPERIMENTAL)
- Add GraphQL schema and HTTP server (read-only)
- Integrate Neo4j lookups in entity extraction and text unit retrieval
- Feature flag controlled via GRAPHRAG_USE_NEO4J
- Fully backward compatible with fallback to dataframe logic

Files:
- 4 new files in graphrag/graph/ (Neo4j client, GraphQL schema/server)
- 2 modified workflow files (entity_extraction.py, text_units.py)
- 1 documentation file (neo4j_graphql_poc.md)

