### PR TITLE
bugfix for lancedb uri parsing when using an object store

### DIFF
--- a/packages/graphrag/graphrag/config/models/graph_rag_config.py
+++ b/packages/graphrag/graphrag/config/models/graph_rag_config.py
@@ -270,9 +270,11 @@ class GraphRagConfig(BaseModel):
         """Validate the vector store configuration."""
         store = self.vector_store
         if store.type == VectorStoreType.LanceDB:
-            if not store.db_uri or store.db_uri.strip == "":
+            if not store.db_uri or store.db_uri.strip() == "":
                 store.db_uri = graphrag_config_defaults.vector_store.db_uri
-            store.db_uri = str(Path(store.db_uri).resolve())
+            # Only convert to a filesystem path if the URI is not for object store
+            if not store.db_uri.startswith(("az://", "s3://", "gs://")):
+                store.db_uri = str(Path(store.db_uri).resolve())
 
     def get_completion_model_config(self, model_id: str) -> ModelConfig:
         """Get a completion model configuration by ID.


### PR DESCRIPTION
## Description

When a `db_uri` for an object store is passed to lancedb, graphrag config parser implicitly converts it to a filesystem path. This PR fixes that and also incorporates https://github.com/microsoft/graphrag/pull/1991

## Related Issues

Will fix https://github.com/microsoft/graphrag/discussions/328#discussioncomment-11769556 and will implicitly address https://github.com/microsoft/graphrag/issues/1306

## Proposed Changes

Only convert db_uri to a filesystem path if it does not start with a well known object store prefix (viz. `az`, `gs`, `s3`). [lancedb uri docs for object stores](https://docs.lancedb.com/storage/configuration#object-stores)

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
