### PR TITLE
fix: avoid releasing un-acquired lock during blob rotation

### DIFF
--- a/tests/unit/test_blob_workflow_logger.py
+++ b/tests/unit/test_blob_workflow_logger.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""Tests for BlobWorkflowLogger blob rotation logic."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from graphrag.logger.blob_workflow_logger import BlobWorkflowLogger
+
+
+@pytest.fixture
+def mock_blob_service():
+    """Create a mock BlobServiceClient and related objects."""
+    with patch(
+        "graphrag.logger.blob_workflow_logger.BlobServiceClient"
+    ) as mock_bsc_cls:
+        mock_blob_client = MagicMock()
+        mock_blob_client.exists.return_value = False
+
+        mock_bsc = MagicMock()
+        mock_bsc.get_blob_client.return_value = mock_blob_client
+
+        mock_bsc_cls.return_value = mock_bsc
+
+        yield mock_bsc, mock_blob_client
+
+
+@pytest.fixture
+def mock_credential():
+    """Mock DefaultAzureCredential."""
+    with patch(
+        "graphrag.logger.blob_workflow_logger.DefaultAzureCredential"
+    ) as mock_cred:
+        yield mock_cred
+
+
+def test_rotate_blob_does_not_reinitialize_handler(
+    mock_blob_service, mock_credential
+):
+    """Test that blob rotation does not call __init__ on the handler.
+
+    This verifies the fix for issue #2170 where calling self.__init__()
+    during rotation caused 'cannot release un-acquired lock' errors.
+    """
+    mock_bsc, mock_blob_client = mock_blob_service
+
+    logger = BlobWorkflowLogger(
+        connection_string=None,
+        container_name="test-container",
+        blob_name="test.logs.json",
+        base_dir="logs",
+        account_url="https://test.blob.core.windows.net",
+    )
+
+    # Simulate reaching max block count
+    logger._num_blocks = logger._max_block_count
+
+    # Store reference to the original lock to verify it's not replaced
+    original_lock = logger.lock
+
+    # Write a log entry, which should trigger rotation
+    logger._write_log({"type": "log", "data": "test message"})
+
+    # Verify the lock was NOT replaced (i.e., __init__ was not called)
+    assert logger.lock is original_lock
+
+    # Verify block counter was reset (rotation happened)
+    # After rotation (reset to 0) + 1 write = 1
+    assert logger._num_blocks == 1
+
+    # Verify a new blob client was created during rotation
+    assert mock_bsc.get_blob_client.call_count > 1
+
+
+def test_rotate_blob_creates_new_blob_name(mock_blob_service, mock_credential):
+    """Test that rotation generates a new blob name."""
+    mock_bsc, mock_blob_client = mock_blob_service
+
+    logger = BlobWorkflowLogger(
+        connection_string=None,
+        container_name="test-container",
+        blob_name="test.logs.json",
+        base_dir="logs",
+        account_url="https://test.blob.core.windows.net",
+    )
+
+    original_blob_name = logger._blob_name
+
+    # Trigger rotation
+    logger._rotate_blob()
+
+    # New blob name should be different (auto-generated with timestamp)
+    assert logger._blob_name != original_blob_name
+    assert logger._num_blocks == 0


### PR DESCRIPTION
## Description

Fix `cannot release un-acquired lock` error in `BlobWorkflowLogger` when the append blob reaches the 25k block limit and needs to rotate to a new blob file.

## Related Issues

Fixes #2170

## Proposed Changes

- Extract blob rotation logic from `__init__` into a new `_rotate_blob()` method
- Store `base_dir` as an instance attribute (`self._base_dir`) so it can be reused during rotation
- Replace `self.__init__()` call in `_write_log()` with `self._rotate_blob()`, avoiding re-initialization of the `logging.Handler` and its lock
- Add unit tests verifying that rotation preserves the handler lock and generates new blob names

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes

The root cause was that `_write_log()` called `self.__init__()` to rotate the blob, which invoked `super().__init__(level)` on `logging.Handler`. This re-created the lock object while the logging machinery still held a reference to the old lock, resulting in the `cannot release un-acquired lock` RuntimeError.