### PR TITLE
fix: remove extra argument in dry-run logger.info call

### DIFF
--- a/packages/graphrag/graphrag/cli/index.py
+++ b/packages/graphrag/graphrag/cli/index.py
@@ -116,7 +116,7 @@ def _run_index(
     )
 
     if dry_run:
-        logger.info("Dry run complete, exiting...", True)
+        logger.info("Dry run complete, exiting...")
         sys.exit(0)
 
     _register_signal_handlers()


### PR DESCRIPTION
## Description

Remove the extraneous `True` argument from `logger.info("Dry run complete, exiting...", True)` in `_run_index()` which caused a `TypeError: not all arguments converted during string formatting` when running `graphrag index --dry-run`.

## Related Issues

Fixes #2254

## Proposed Changes

- Remove the extra `True` argument from `logger.info()` call at `cli/index.py:119`

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes

One-line fix. The `True` was likely a leftover from a previous API where the second argument controlled some behavior. Standard `logging.info()` interprets positional args as format string arguments.