### PR TITLE
fix: preserve nodes with unassigned community level in filtering

### DIFF
--- a/packages/graphrag/graphrag/query/indexer_adapters.py
+++ b/packages/graphrag/graphrag/query/indexer_adapters.py
@@ -221,5 +221,5 @@ def _filter_under_community_level(
 ) -> pd.DataFrame:
     return cast(
         "pd.DataFrame",
-        df[df.level <= community_level],
+        df[(df.level <= community_level) | df.level.isna()],
     )

--- a/tests/unit/query/test_filter_community_level.py
+++ b/tests/unit/query/test_filter_community_level.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""Tests for _filter_under_community_level preserving NaN-level nodes."""
+
+import numpy as np
+import pandas as pd
+
+from graphrag.query.indexer_adapters import _filter_under_community_level
+
+
+def test_filter_preserves_nan_level_nodes():
+    """Nodes with level=NaN should not be discarded by the filter.
+
+    Regression test for issue #1808 where isolated nodes without a community
+    assignment (level=None) were incorrectly dropped.
+    """
+    df = pd.DataFrame({
+        "id": ["a", "b", "c", "d"],
+        "level": [0, 1, 2, np.nan],
+        "community": [1, 2, 3, np.nan],
+    })
+
+    result = _filter_under_community_level(df, community_level=1)
+
+    # Should keep level 0, 1 (<=1) and NaN (unassigned)
+    assert len(result) == 3
+    assert set(result["id"].tolist()) == {"a", "b", "d"}
+
+
+def test_filter_excludes_higher_level_nodes():
+    """Nodes with level > community_level should be excluded."""
+    df = pd.DataFrame({
+        "id": ["a", "b", "c"],
+        "level": [0, 2, 3],
+        "community": [1, 2, 3],
+    })
+
+    result = _filter_under_community_level(df, community_level=1)
+
+    assert len(result) == 1
+    assert result["id"].tolist() == ["a"]


### PR DESCRIPTION
## Description

Fix `_filter_under_community_level` to retain nodes where `level` is NaN, which represent isolated nodes not assigned to any community by the Leiden algorithm. Previously these nodes were silently dropped because NaN comparisons always evaluate to False in pandas, causing approximately 10% data loss.

## Related Issues

Fixes #1808

## Proposed Changes

- Add `| df.level.isna()` condition to `_filter_under_community_level` so NaN-level nodes are preserved
- Add unit tests verifying both NaN preservation and correct level filtering

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes

Downstream code already handles NaN community values with `fillna(-1)`, so preserving these nodes is consistent with the existing data flow.