### PR TITLE
[1.2.0] fix(security): bump nltk to >=3.9.3 to remediate CVE-2025-14009

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ aiofiles = "^24.1.0"
 
 # LLM
 openai = "^1.57.0"
-nltk = "3.9.1"
+nltk = ">=3.9.3,<4.0.0"
 tiktoken = "^0.8.0"
 
 # Data-Sci


### PR DESCRIPTION
Proposing a change so that CVE-2025-14009 can be resolved and allow for future library patches