### PR TITLE
bump nltk to resolve [CVE-2025-14009](https://github.com/advisories/GHSA-7p94-766c-hgjp)

### DIFF
--- a/.semversioner/next-release/patch-20260327141426995340.json
+++ b/.semversioner/next-release/patch-20260327141426995340.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "bump nltk to resolve [CVE-2025-14009](https://github.com/advisories/GHSA-7p94-766c-hgjp)"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "fnllm[azure,openai]>=0.4.1",
     "json-repair>=0.30.3",
     "openai>=1.68.0",
-    "nltk==3.9.1",
+    "nltk>=3.9.3,<4",
     "tiktoken>=0.11.0",
     # Data-Science
     "numpy>=1.25.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1344,7 +1344,7 @@ requires-dist = [
     { name = "lancedb", specifier = ">=0.17.0" },
     { name = "litellm", specifier = ">=1.77.1" },
     { name = "networkx", specifier = ">=3.4.2" },
-    { name = "nltk", specifier = "==3.9.1" },
+    { name = "nltk", specifier = ">=3.9.3,<4" },
     { name = "numpy", specifier = ">=1.25.2" },
     { name = "openai", specifier = ">=1.68.0" },
     { name = "pandas", specifier = ">=2.2.3,<3" },
@@ -2752,7 +2752,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.1"
+version = "3.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2760,9 +2760,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/87/db8be88ad32c2d042420b6fd9ffd4a149f9a0d7f0e86b3f543be2eeeedd2/nltk-3.9.1.tar.gz", hash = "sha256:87d127bd3de4bd89a4f81265e5fa59cb1b199b27440175370f7417d2bc7ae868", size = 2904691, upload-time = "2024-08-18T19:48:37.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/66/7d9e26593edda06e8cb531874633f7c2372279c3b0f46235539fe546df8b/nltk-3.9.1-py3-none-any.whl", hash = "sha256:4fa26829c5b00715afe3061398a8989dc643b92ce7dd93fb4585a70930d168a1", size = 1505442, upload-time = "2024-08-18T19:48:21.909Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
bump nltk to resolve [CVE-2025-14009](https://github.com/advisories/GHSA-7p94-766c-hgjp)
