### PR TITLE
chore: add generator return type hints to query/llm/text_utils.py

### DIFF
--- a/.semversioner/next-release/patch-20260421020145168929.json
+++ b/.semversioner/next-release/patch-20260421020145168929.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Add return type hints to generator functions in query/llm/text_utils.py"
+}

--- a/packages/graphrag/graphrag/query/llm/text_utils.py
+++ b/packages/graphrag/graphrag/query/llm/text_utils.py
@@ -17,7 +17,7 @@ from graphrag.tokenizer.get_tokenizer import get_tokenizer
 logger = logging.getLogger(__name__)
 
 
-def batched(iterable: Iterator, n: int):
+def batched(iterable: Iterator, n: int) -> Iterator[tuple]:
     """
     Batch data into tuples of length n. The last batch may be shorter.
 
@@ -32,7 +32,7 @@ def batched(iterable: Iterator, n: int):
         yield batch
 
 
-def chunk_text(text: str, max_tokens: int, tokenizer: Tokenizer | None = None):
+def chunk_text(text: str, max_tokens: int, tokenizer: Tokenizer | None = None) -> Iterator[str]:
     """Chunk text by token length."""
     if tokenizer is None:
         tokenizer = get_tokenizer()


### PR DESCRIPTION
## Description

Add missing return type hints to two generator functions in `packages/graphrag/graphrag/query/llm/text_utils.py`.

## Related Issues

Closes #2330

## Proposed Changes

- `batched(iterable: Iterator, n: int)` → adds `-> Iterator[tuple]`
- `chunk_text(text: str, max_tokens: int, tokenizer: Tokenizer | None = None)` → adds `-> Iterator[str]`

`Iterator` was already imported from `collections.abc`; no new imports required.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes

Verified with `mypy packages/graphrag/graphrag/query/llm/text_utils.py --ignore-missing-imports` — no issues. The pre-existing `import-not-found` errors in the baseline are caused by uninstalled monorepo sub-packages and are unrelated to this change.
