### PR TITLE
fix(query): ensure nodes missing level attributes are included in context

### DIFF
--- a/packages/graphrag/graphrag/query/indexer_adapters.py
+++ b/packages/graphrag/graphrag/query/indexer_adapters.py
@@ -221,5 +221,5 @@ def _filter_under_community_level(
 ) -> pd.DataFrame:
     return cast(
         "pd.DataFrame",
-        df[df.level <= community_level],
+        df[(df.level.isna()) | (df.level <= community_level)],
     )

--- a/tests/unit/query/test_indexer_adapters.py
+++ b/tests/unit/query/test_indexer_adapters.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+import pandas as pd
+from graphrag.query.indexer_adapters import _filter_under_community_level
+
+
+def test_filter_under_community_level_keeps_missing_levels() -> None:
+    df = pd.DataFrame({
+        "id": [
+            "missing_nan",
+            "missing_none",
+            "below_threshold",
+            "at_threshold",
+            "above_threshold",
+        ],
+        "level": [float("nan"), None, 1, 2, 3],
+    })
+
+    result = _filter_under_community_level(df, community_level=2)
+
+    assert result["id"].to_list() == [
+        "missing_nan",
+        "missing_none",
+        "below_threshold",
+        "at_threshold",
+    ]


### PR DESCRIPTION
Fixes #1808

## Problem
In GraphRAG's query engine, the `_filter_under_community_level` utility aggressively filters out any nodes that are missing the `level` attribute. This happens because pandas comparison `df.level <= community_level` returns `False` for `NaN` or `None` values, causing these nodes to be silently dropped from the query context. This leads to incomplete or hallucinated answers.

## Solution
Updated the filtering logic to explicitly include nodes where the `level` attribute is `NaN`. This ensures that all relevant graph data is considered during query execution, regardless of metadata completeness.

## Changes
- `packages/graphrag/graphrag/query/indexer_adapters.py`: Updated `_filter_under_community_level` to handle `NaN` values gracefully.

## Verification
- Verified that the filter now uses a logical OR to preserve nodes with missing levels.