### PR TITLE
feat: native CosmosTableProvider with namespace partitioning

### DIFF
--- a/.semversioner/next-release/minor-20260511223255237407.json
+++ b/.semversioner/next-release/minor-20260511223255237407.json
@@ -1,0 +1,4 @@
+{
+  "type": "minor",
+  "description": "Native CosmosTableProvider with namespace partitioning, transactional batch writes, and simplified AzureCosmosStorage."
+}

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -210,6 +210,14 @@ epitheg
 unspooled
 unnavigated
 
+# Cosmos DB
+aiohttp
+aiter
+colls
+serde
+upserts
+vnext
+
 # Names
 Hochul
 Ashish

--- a/packages/graphrag-storage/COSMOS_TABLE_PROVIDER_DESIGN.md
+++ b/packages/graphrag-storage/COSMOS_TABLE_PROVIDER_DESIGN.md
@@ -1,0 +1,433 @@
+# CosmosTableProvider Design
+
+## Status
+
+**Implemented.** Core provider, factory wiring, pipeline refactoring, and simplified
+key-value storage are complete. Tested against the Cosmos DB Linux emulator (vNext).
+The `graphrag migrate-cosmos` CLI tool is planned but not yet built.
+
+## Problem Statement
+
+The current `AzureCosmosStorage` shoehorns Cosmos DB into a blob/file `Storage` abstraction.
+This causes:
+
+| Issue | Impact |
+|-------|--------|
+| Parquet round-trip: DataFrame → parquet → DataFrame → JSON → Cosmos → reverse | 4 serde hops per read and write |
+| Every document is its own partition (`/id`) | All queries are cross-partition fan-outs — the most expensive Cosmos pattern |
+| Entity-specific hacks in the storage layer (`if prefix == "entities":`) | Domain logic leaking into generic abstraction |
+| `child()` is a no-op (`return self`) | Update runs have no namespace isolation — delta/previous collide |
+| `clear()` drops the entire database | No granularity control |
+| Sync SDK used inside async methods | Blocks the event loop |
+| Unparameterized f-string queries | SQL injection surface (suppressed with noqa) |
+
+## Design: `CosmosTableProvider`
+
+Implement `TableProvider` directly for Cosmos DB, bypassing the `Storage` layer entirely for tabular data.
+
+### Architecture
+
+```
+                      ┌─────────────────────────────┐
+                      │     PipelineRunContext       │
+                      ├──────────┬──────────────────┤
+                      │ Storage  │  TableProvider    │
+                      │(kv only) │                   │
+                      ├──────────┼──────────────────┤
+  File/Blob backend → │file_stor │ ParquetTableProv │ ← File/Blob pipeline
+                      ├──────────┼──────────────────┤
+  Cosmos backend    → │cosmos_kv │ CosmosTableProv  │ ← Cosmos pipeline
+                      │(metadata)│  (native docs)   │
+                      └──────────┴──────────────────┘
+```
+
+### Cosmos Document Schema
+
+**Container:** single container (configurable, default `graphrag`)  
+**Partition key:** `/namespace`
+
+```json
+{
+    "id":         "entities:42",
+    "namespace":  "output",
+    "table_name": "entities",
+    
+    "name":       "JOHN DOE",
+    "type":       "PERSON",
+    "description": "A character in ...",
+    "human_readable_id": 42
+}
+```
+
+| Field | Purpose | Indexed |
+|-------|---------|---------|
+| `id` | Unique within namespace. Format: `{table_name}:{row_key}` | Yes (built-in) |
+| `namespace` | Partition key. Isolation boundary for child() hierarchy | Yes (partition key) |
+| `table_name` | Discriminator for per-table queries within a namespace | Yes (composite index) |
+| All other fields | DataFrame columns stored as top-level document properties | Configurable |
+
+### Namespace Mapping
+
+```
+output_table_provider            → namespace = ""  (root / default)
+update/20260511/delta            → namespace = "20260511/delta"
+update/20260511/previous         → namespace = "20260511/previous"
+```
+
+`child("delta")` returns a new `CosmosTableProvider` sharing the same client, with namespace extended.
+
+### Query Patterns (All Single-Partition)
+
+| Operation | Query | Partition |
+|-----------|-------|-----------|
+| `read_dataframe("entities")` | `SELECT * FROM c WHERE c.table_name = 'entities'` | `namespace` |
+| `write_dataframe("entities", df)` | Bulk upsert with `namespace` and `table_name` set | `namespace` |
+| `has("entities")` | `SELECT VALUE COUNT(1) FROM c WHERE c.table_name = 'entities'` | `namespace` |
+| `list()` | `SELECT DISTINCT VALUE c.table_name FROM c` | `namespace` |
+| `clear()` | Delete all docs in namespace partition | `namespace` |
+
+**Zero cross-partition queries.** Every query targets a single `namespace` partition.
+
+### Row Identity
+
+Each row needs a stable Cosmos `id`. Strategy per table:
+
+- If the DataFrame has an `id` column: use `{table_name}:{id}`
+- Otherwise: use `{table_name}:{index}` (positional)
+
+The pipeline's `id` column is preserved as a regular document property. Cosmos's `id` is the synthetic key above. No column renaming — the pipeline's `id` and Cosmos's `id` happen to share the field, but we store the pipeline value in a separate `_row_id` field if collision occurs.
+
+**Simpler approach chosen:** always store pipeline `id` (if present) as `row_id`, and use `{table_name}:{human_readable_id or index}` as Cosmos `id`. This avoids all the entity-specific hacks in the current implementation.
+
+### Streaming (Table.open())
+
+`CosmosTable` implements the `Table` ABC:
+
+- `__aiter__`: pages through `query_items()` using the async SDK, yields rows one at a time
+- `write(row)`: accumulates rows in memory (same as `ParquetTable`)
+- `close()`: bulk upserts accumulated rows
+- `has(row_id)`: point-read by `id` within namespace (single RU)
+
+True server-side streaming — no full-DataFrame materialization on read unless `read_dataframe()` is called.
+
+## Changes (Implemented)
+
+### 1. `child()` added to `TableProvider` ABC
+
+Non-abstract method with default no-op. Backward compatible — no existing code breaks.
+
+### 2. `ParquetTableProvider.child()` and `CSVTableProvider.child()`
+
+Both delegate to their underlying `Storage.child()`. Existing File/Blob pipelines
+work identically.
+
+### 3. `CosmosTableProvider` class — `cosmos_table_provider.py` (~320 lines)
+
+Implements `TableProvider` directly. Owns an async `CosmosClient` (`azure.cosmos.aio`).
+No `Storage` dependency.
+
+Key features:
+- Lazy container creation via `_ensure_container()` (async init deferred from `__init__`)
+- `child()` returns a new instance sharing the same client with extended namespace
+- Legacy fallback reads from old `AzureCosmosStorage` containers (when `legacy_container` configured)
+- `_LazyCosmosTable` wrapper to bridge synchronous `open()` with async container init
+
+### 4. `CosmosTable` class — `cosmos_table.py` (~160 lines)
+
+Implements `Table` ABC for streaming row access:
+- `__aiter__`: async iteration with server-side pagination via `by_page()`
+- `length()`: single-partition COUNT query
+- `has()`: point-read by composite id
+- `write()` / `close()`: accumulate-then-upsert pattern (same as `ParquetTable`)
+- `_delete_table_docs()`: truncate before overwrite
+
+### 5. Factory and config wiring
+
+- `TableType.CosmosDB = "cosmosdb"` added to enum
+- `TableProviderConfig` gained: `connection_string`, `account_url`, `database_name`,
+  `container_name`, `legacy_container` fields
+- `table_provider_factory.py` lazy-registers `CosmosTableProvider` on `cosmosdb` type
+
+### 6. Pipeline wiring refactored
+
+`run_pipeline.py` and `get_update_table_providers()` in `utils.py` now use
+`table_provider.child()` to build delta/previous providers instead of
+`Storage.child()` → `create_table_provider()`.
+
+For Parquet/CSV: `child()` delegates to `Storage.child()`, identical behaviour.
+For Cosmos: `child()` extends the namespace string. Same API, different isolation mechanism.
+
+### 7. `AzureCosmosStorage` simplified to key-value only (~200 lines, was ~440)
+
+Removed:
+- All parquet decomposition/recomposition logic
+- Entity-specific `if prefix == "entities":` hacks
+- `_no_id_prefixes` tracking
+- `pandas` / `BytesIO` / `StringIO` imports
+- `_query_all_items` / `_query_count` helper methods
+- `_get_prefix` method
+- `graphrag.logger.progress` import
+
+Added:
+- Working `child()` via namespace prefix (separator: `:` — see caveat below)
+- Scoped `clear()`: container drop-and-recreate for root, prefix-query-and-delete for children
+- `keys()` implementation (was `raise NotImplementedError`)
+
+## Implementation Caveats Discovered During Testing
+
+### Cosmos DB document IDs cannot contain `/`
+
+The Azure Cosmos DB SDK uses the document `id` as part of the REST URL path
+(e.g. `/dbs/{db}/colls/{coll}/docs/{id}`). If `id` contains `/`, the SDK
+interprets it as additional path segments and the request fails with
+`"Id contains illegal chars."` on write or HTTP 400 on read.
+
+**Impact on `AzureCosmosStorage`:** The key-value store uses `id` as the
+partition key (`/id`). `child()` namespacing must NOT use `/` as separator.
+We use `:` instead: `child("cache").child("gpt4o")` produces keys like
+`cache:gpt4o:abc123`.
+
+**Impact on `CosmosTableProvider`:** No impact. The namespace is stored in a
+separate `namespace` field (the partition key is `/namespace`), and the
+document `id` uses the format `{table_name}:{row_key}` with `:` as
+separator. The namespace value itself can contain `/` freely because
+it's a partition key value, not a document id.
+
+### `list()` is synchronous in the ABC but Cosmos queries are async
+
+The `TableProvider.list()` method is declared synchronous (no `async`). The
+Cosmos implementation needs to run an async query. We solve this with
+`_list_async()` and a sync wrapper that detects whether an event loop is
+running, using a thread pool executor as fallback. This matches the pattern
+used elsewhere in the codebase.
+
+## What We Get
+
+| Before | After |
+|--------|-------|
+| 4 serde hops per read/write | 1 hop (DataFrame ↔ Cosmos docs directly) |
+| All cross-partition queries | All single-partition queries |
+| Entity-specific hacks in storage layer | No domain logic in storage layer |
+| `child()` broken (no-op) | `child()` works via namespace partitioning |
+| `clear()` drops entire database | `clear()` scopes to namespace partition |
+| Sync SDK blocking event loop | Async SDK throughout |
+| Unparameterized queries | All queries parameterized |
+| ~440 lines of workaround code | ~950 lines total (326 kv-storage + 453 table-provider + 171 table) — clean, idiomatic Cosmos code |
+| Parquet as intermediate format | No parquet involved for Cosmos path |
+| No streaming capability | True server-side pagination in `CosmosTable` |
+
+## What We Don't Change
+
+- `Storage` ABC — untouched
+- `FileStorage`, `AzureBlobStorage`, `MemoryStorage` — untouched
+- `ParquetTableProvider`, `CSVTableProvider` — gain `child()`, otherwise untouched
+- Pipeline workflows — untouched (they call `TableProvider` methods, not `Storage`)
+- `JsonCache` — untouched (uses `Storage.child()`, separate from table provider)
+- Input readers (`graphrag-input`) — untouched (use `Storage` directly)
+
+## Migration / Backward Compatibility
+
+### The Hard Constraint: Partition Keys Are Immutable
+
+The current container uses `/id` as its partition key. The new schema requires `/namespace`.
+**Cosmos DB does not allow changing a container's partition key after creation.**
+This means migration requires a new container — you cannot transform documents in-place.
+
+### Legacy Document Schemas (Current `AzureCosmosStorage`)
+
+There are three document shapes in the old container, all sharing partition key `/id`:
+
+```
+# Shape 1: Tabular row (non-entity)
+{"id": "relationships:42", "source": "A", "target": "B", "weight": 0.8, ...}
+                 ↑ partition key = "relationships:42"
+
+# Shape 2: Tabular row (entity — special-cased)
+{"id": "entities:7", "entity_id": "abc-uuid", "human_readable_id": 7, "name": "FOO", ...}
+                ↑ partition key = "entities:7"
+                   ↑ pipeline's real id, renamed to avoid collision
+
+# Shape 3: Key-value metadata
+{"id": "context.json", "body": {"step": "extract_graph", ...}}
+                  ↑ partition key = "context.json"
+```
+
+### New Document Schema (CosmosTableProvider)
+
+Single container, partition key `/namespace`:
+
+```
+# Shape 1 & 2 unified: Tabular row (all tables, no special cases)
+{"id": "entities:7", "namespace": "output", "table_name": "entities",
+ "row_id": "abc-uuid", "human_readable_id": 7, "name": "FOO", ...}
+                      ↑ partition key = "output"
+
+# Shape 3: Unchanged, stays in simplified AzureCosmosStorage (separate container)
+{"id": "context.json", "body": {"step": "extract_graph", ...}}
+```
+
+### Migration Scenarios
+
+| Scenario | User Action | Migration Needed |
+|----------|-------------|------------------|
+| **Fresh install** (no existing data) | Set `table_provider.type: cosmosdb` in config | None — new container created automatically |
+| **Existing File/Blob → Cosmos** | Change config, re-index | None — fresh write to new container |
+| **Existing Cosmos data (legacy)** | Change config, run `graphrag migrate-cosmos` | Yes — see below |
+| **Stay on current Cosmos impl** | No config change | None — old code still works |
+
+### Migration Strategy: Dual-Container with CLI Tool
+
+#### Container Layout (Post-Migration)
+
+```
+Database: graphrag
+├── Container: graphrag-kv      ← simplified AzureCosmosStorage (partition key: /id)
+│   ├── {"id": "context.json", "body": {...}}
+│   ├── {"id": "stats.json", "body": {...}}
+│   └── {"id": "report.graphml", "body": "..."}
+│
+└── Container: graphrag-tables  ← CosmosTableProvider (partition key: /namespace)
+    ├── {"id": "entities:0", "namespace": "output", "table_name": "entities", ...}
+    ├── {"id": "entities:1", "namespace": "output", "table_name": "entities", ...}
+    ├── {"id": "relationships:0", "namespace": "output", "table_name": "relationships", ...}
+    └── ...
+```
+
+Separation is natural: the key-value data (context, stats, graphml, cache) has trivially
+small volume and the `/id` partition key is fine for point-reads. Tabular data benefits
+from the `/namespace` partition key for efficient scans.
+
+#### CLI Migration Command
+
+```bash
+graphrag migrate-cosmos \
+  --account-url https://myaccount.documents.azure.com:443/ \
+  --database graphrag \
+  --legacy-container graphrag-output \
+  --target-container graphrag-tables \
+  --namespace output
+```
+
+The tool:
+1. Connects to the legacy container (partition key `/id`)
+2. Discovers all `{prefix}:*` documents via cross-partition query (one final fan-out)
+3. Groups documents by prefix → table name
+4. For each table:
+   - Reverses entity-specific hacks (`entity_id` → `row_id`, etc.)
+   - Adds `namespace` and `table_name` fields
+   - Bulk-upserts into the target container (partition key `/namespace`)
+5. Copies key-value documents (`context.json`, `stats.json`, etc.) to the kv container
+6. Prints a summary: tables migrated, row counts, RU consumption
+7. Does NOT delete the legacy container (user does that manually after verification)
+
+#### Transparent Fallback (Read-Time Compat)
+
+For users who switch config before running the migration tool, `CosmosTableProvider`
+includes a **read-time fallback**:
+
+1. `read_dataframe("entities")` queries the new container first
+2. If the table is empty/missing AND a `legacy_container` is configured, falls back
+   to reading from the legacy container using the old `{prefix}:*` query pattern
+3. Normalizes the legacy documents (strip prefix from id, reverse entity hacks,
+   add `namespace`/`table_name`) and returns the DataFrame
+4. Logs a warning: `"Reading from legacy container — run 'graphrag migrate-cosmos' to complete migration"`
+5. Does NOT auto-write to the new container (migration is explicit, not side-effect)
+
+This means:
+- **Reads work immediately** after config change, even without running migration
+- **Writes always go to the new container** with the new schema
+- **A re-index** (which reads then writes everything) effectively migrates all data
+- The explicit migration tool is for users who want to migrate without re-indexing
+
+#### Config Change Required
+
+```yaml
+# Before (legacy)
+output_storage:
+  type: cosmosdb
+  account_url: https://myaccount.documents.azure.com:443/
+  database_name: graphrag
+  container_name: graphrag-output
+
+# After (new)
+output_storage:
+  type: cosmosdb                           # simplified to key-value only
+  account_url: https://myaccount.documents.azure.com:443/
+  database_name: graphrag
+  container_name: graphrag-kv              # new container for metadata
+
+table_provider:
+  type: cosmosdb                           # NEW — routes to CosmosTableProvider
+  account_url: https://myaccount.documents.azure.com:443/
+  database_name: graphrag
+  container_name: graphrag-tables          # new container for tabular data
+  legacy_container: graphrag-output        # optional — enables read-time fallback
+```
+
+When `legacy_container` is set, the fallback read path is active. Once migration is
+complete and verified, the user removes `legacy_container` from config and optionally
+deletes the old container.
+
+#### Migration Safety
+
+- **Idempotent:** Running the migration tool multiple times is safe (upsert semantics)
+- **Non-destructive:** Legacy container is never modified or deleted by the tool
+- **Resumable:** If interrupted, re-run picks up where it left off (upserts are atomic)
+- **Verifiable:** Tool prints row counts per table; user can compare against legacy
+- **Rollback:** If anything goes wrong, delete the new container and revert config
+
+#### What Happens to Cache Data?
+
+LLM cache data (`JsonCache`) uses `Storage.child()` for namespacing. This stays on the
+`AzureCosmosStorage` (key-value) path. Cache documents are small JSON blobs with
+`{"id": key, "body": {...}}` format — they work fine with `/id` as partition key since
+they're always accessed by point-read. No migration needed for cache data.
+
+If the user was previously using a single container for both cache and output, the
+migration tool separates them: tabular data goes to `graphrag-tables`, key-value data
+(including cache) stays in the legacy container (or moves to `graphrag-kv`).
+
+## Tables
+
+7 tables managed by the provider:
+
+`documents`, `text_units`, `entities`, `relationships`, `covariates`, `communities`, `community_reports`
+
+Embeddings are written via table provider as `embeddings.{name}` — these become `table_name = "embeddings.entity_description"` etc.
+
+## File Inventory
+
+| File | Action | Status |
+|------|--------|--------|
+| `graphrag_storage/tables/table_provider.py` | Add `child()` default method | ✅ Done |
+| `graphrag_storage/tables/table_type.py` | Add `CosmosDB` enum value | ✅ Done |
+| `graphrag_storage/tables/table_provider_config.py` | Add Cosmos + legacy_container fields | ✅ Done |
+| `graphrag_storage/tables/cosmos_table_provider.py` | **New** — main implementation (453 lines) | ✅ Done |
+| `graphrag_storage/tables/cosmos_table.py` | **New** — streaming Table impl (171 lines) | ✅ Done |
+| `graphrag_storage/tables/table_provider_factory.py` | Add cosmosdb case | ✅ Done |
+| `graphrag_storage/tables/parquet_table_provider.py` | Add `child()` method | ✅ Done |
+| `graphrag_storage/tables/csv_table_provider.py` | Add `child()` method | ✅ Done |
+| `graphrag_storage/azure_cosmos_storage.py` | Simplified to key-value only (326 lines) | ✅ Done |
+| `graphrag/index/run/utils.py` | Refactor `get_update_table_providers` | ✅ Done |
+| `graphrag/index/run/run_pipeline.py` | Use `table_provider.child()` for update runs | ✅ Done |
+| `graphrag/cli/migrate_cosmos.py` | **New** — CLI migration tool | ⬜ Planned |
+| `graphrag/cli/main.py` | Register `migrate-cosmos` subcommand | ⬜ Planned |
+
+## Testing
+
+### Unit / verb tests
+
+302 unit tests + 15 verb tests pass (unchanged from baseline). The pipeline
+wiring refactor is backward-compatible for File/Blob/Memory backends.
+
+### E2E tests against Cosmos emulator
+
+Tested against `mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview`
+(ARM64-compatible, vNext emulator using HTTP on port 8081).
+
+| Test | Checks | Status |
+|------|--------|--------|
+| CosmosTableProvider lifecycle | write, read, has, list, child, open, stream, truncate | ✅ 11/11 |
+| AzureCosmosStorage key-value | set, get, has, child, keys, delete, clear | ✅ 7/7 |
+| Factory wiring | config → CosmosTableProvider, child() | ✅ 3/3 |
+| Update run simulation | delta/previous/output namespace isolation, merge | ✅ 7/7 |

--- a/packages/graphrag-storage/COSMOS_TABLE_PROVIDER_DESIGN.md
+++ b/packages/graphrag-storage/COSMOS_TABLE_PROVIDER_DESIGN.md
@@ -369,12 +369,14 @@ output_storage:
   container_name: graphrag-kv              # new container for metadata
 
 table_provider:
-  type: cosmosdb                           # NEW — routes to CosmosTableProvider
-  account_url: https://myaccount.documents.azure.com:443/
-  database_name: graphrag
-  container_name: graphrag-tables          # new container for tabular data
-  legacy_container: graphrag-output        # optional — enables read-time fallback
+  type: cosmosdb                           # NEW - routes to CosmosTableProvider
+  container_name: graphrag-tables          # table-specific: new container for tabular data
+  legacy_container: graphrag-output        # table-specific: optional migration fallback
 ```
+
+Connection details (`account_url`, `connection_string`, `database_name`) are NOT
+duplicated on `table_provider`. The factory extracts them from `output_storage`
+automatically when `table_provider.type` is `cosmosdb`.
 
 When `legacy_container` is set, the fallback read path is active. Once migration is
 complete and verified, the user removes `legacy_container` from config and optionally

--- a/packages/graphrag-storage/COSMOS_TABLE_PROVIDER_DESIGN.md
+++ b/packages/graphrag-storage/COSMOS_TABLE_PROVIDER_DESIGN.md
@@ -201,6 +201,18 @@ Cosmos implementation needs to run an async query. We solve this with
 running, using a thread pool executor as fallback. This matches the pattern
 used elsewhere in the codebase.
 
+### `enable_cross_partition_query` doesn't work in async SDK (v4.9)
+
+The async SDK (`azure.cosmos.aio`) leaks `enable_cross_partition_query` through
+to `aiohttp.ClientSession._request()`, causing a `TypeError`. This affects
+legacy fallback reads which must do cross-partition queries against old containers
+(partition key `/id`).
+
+**Workaround:** Omit `enable_cross_partition_query` entirely and don't set
+`partition_key`. When `partition_key` is omitted, the async SDK automatically
+performs a cross-partition query. New-schema queries are unaffected because they
+always target a single namespace partition.
+
 ## What We Get
 
 | Before | After |

--- a/packages/graphrag-storage/COSMOS_TABLE_PROVIDER_DESIGN.md
+++ b/packages/graphrag-storage/COSMOS_TABLE_PROVIDER_DESIGN.md
@@ -19,7 +19,7 @@ This causes:
 | `child()` is a no-op (`return self`) | Update runs have no namespace isolation — delta/previous collide |
 | `clear()` drops the entire database | No granularity control |
 | Sync SDK used inside async methods | Blocks the event loop |
-| Unparameterized f-string queries | SQL injection surface (suppressed with noqa) |
+| Non-parameterized f-string queries | SQL injection surface (suppressed with noqa) |
 
 ## Design: `CosmosTableProvider`
 
@@ -154,7 +154,7 @@ Implements `Table` ABC for streaming row access:
 `table_provider.child()` to build delta/previous providers instead of
 `Storage.child()` → `create_table_provider()`.
 
-For Parquet/CSV: `child()` delegates to `Storage.child()`, identical behaviour.
+For Parquet/CSV: `child()` delegates to `Storage.child()`, identical behavior.
 For Cosmos: `child()` extends the namespace string. Same API, different isolation mechanism.
 
 ### 7. `AzureCosmosStorage` simplified to key-value only (~200 lines, was ~440)
@@ -223,7 +223,7 @@ always target a single namespace partition.
 | `child()` broken (no-op) | `child()` works via namespace partitioning |
 | `clear()` drops entire database | `clear()` scopes to namespace partition |
 | Sync SDK blocking event loop | Async SDK throughout |
-| Unparameterized queries | All queries parameterized |
+| Non-parameterized queries | All queries parameterized |
 | ~440 lines of workaround code | ~950 lines total (326 kv-storage + 453 table-provider + 171 table) — clean, idiomatic Cosmos code |
 | Parquet as intermediate format | No parquet involved for Cosmos path |
 | No streaming capability | True server-side pagination in `CosmosTable` |

--- a/packages/graphrag-storage/graphrag_storage/azure_cosmos_storage.py
+++ b/packages/graphrag-storage/graphrag_storage/azure_cosmos_storage.py
@@ -1,22 +1,26 @@
 # Copyright (c) 2024 Microsoft Corporation.
 # Licensed under the MIT License
 
-"""Azure CosmosDB Storage implementation of PipelineStorage."""
+"""Azure CosmosDB key-value Storage implementation.
+
+This module provides a simple key-value store on top of Cosmos DB for
+non-tabular data: pipeline state (context.json, stats.json), GraphML
+snapshots, and LLM cache entries.
+
+Tabular data (DataFrames / parquet) should use CosmosTableProvider instead.
+"""
 
 import json
 import logging
 import re
 from collections.abc import Iterator
 from datetime import datetime, timezone
-from io import BytesIO, StringIO
 from typing import Any
 
-import pandas as pd
 from azure.cosmos import ContainerProxy, CosmosClient, DatabaseProxy
 from azure.cosmos.exceptions import CosmosResourceNotFoundError
 from azure.cosmos.partition_key import PartitionKey
 from azure.identity import DefaultAzureCredential
-from graphrag.logger.progress import Progress
 
 from graphrag_storage.storage import (
     Storage,
@@ -25,21 +29,25 @@ from graphrag_storage.storage import (
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_PAGE_SIZE = 100
-
 
 class AzureCosmosStorage(Storage):
-    """The CosmosDB-Storage Implementation."""
+    """Key-value storage backed by Azure Cosmos DB.
+
+    Each item is stored as ``{"id": key, "body": <parsed JSON or string>}``.
+    The partition key is ``/id``, so every read/write is a single-partition
+    point operation.
+
+    For namespace isolation (e.g. update-run delta/previous), ``child()``
+    creates a new instance that prefixes all keys with ``{namespace}/``.
+    """
 
     _cosmos_client: CosmosClient
     _database_client: DatabaseProxy | None
     _container_client: ContainerProxy | None
-    _cosmosdb_account_url: str | None
-    _connection_string: str | None
     _database_name: str
     _container_name: str
     _encoding: str
-    _no_id_prefixes: set[str]
+    _namespace: str
 
     def __init__(
         self,
@@ -48,19 +56,17 @@ class AzureCosmosStorage(Storage):
         connection_string: str | None = None,
         account_url: str | None = None,
         encoding: str = "utf-8",
+        namespace: str = "",
         **kwargs: Any,
     ) -> None:
-        """Create a CosmosDB storage instance."""
-        logger.info("Creating cosmosdb storage")
-        database_name = database_name
+        """Create a CosmosDB key-value storage instance."""
+        logger.info("Creating CosmosDB key-value storage")
         if not database_name:
-            msg = "CosmosDB Storage requires a base_dir to be specified. This is used as the database name."
-            logger.error(msg)
+            msg = "CosmosDB Storage requires 'database_name'."
             raise ValueError(msg)
 
         if connection_string is not None and account_url is not None:
-            msg = "CosmosDB Storage requires either a connection_string or cosmosdb_account_url to be specified, not both."
-            logger.error(msg)
+            msg = "Specify either 'connection_string' or 'account_url', not both."
             raise ValueError(msg)
 
         if connection_string:
@@ -71,8 +77,7 @@ class AzureCosmosStorage(Storage):
                 credential=DefaultAzureCredential(),
             )
         else:
-            msg = "CosmosDB Storage requires either a connection_string or cosmosdb_account_url to be specified."
-            logger.error(msg)
+            msg = "CosmosDB Storage requires 'connection_string' or 'account_url'."
             raise ValueError(msg)
 
         self._encoding = encoding
@@ -80,35 +85,23 @@ class AzureCosmosStorage(Storage):
         self._connection_string = connection_string
         self._cosmosdb_account_url = account_url
         self._container_name = container_name
-        self._cosmosdb_account_name = (
-            account_url.split("//")[1].split(".")[0] if account_url else None
-        )
-        self._no_id_prefixes = set()
-        logger.debug(
-            "Creating cosmosdb storage with account [%s] and database [%s] and container [%s]",
-            self._cosmosdb_account_name,
-            self._database_name,
-            self._container_name,
-        )
+        self._namespace = namespace
+        self._database_client = None
+        self._container_client = None
+
         self._create_database()
         self._create_container()
 
+    # ------------------------------------------------------------------
+    # Internal DB / container management
+    # ------------------------------------------------------------------
+
     def _create_database(self) -> None:
-        """Create the database if it doesn't exist."""
         self._database_client = self._cosmos_client.create_database_if_not_exists(
             id=self._database_name
         )
 
-    def _delete_database(self) -> None:
-        """Delete the database if it exists."""
-        if self._database_client:
-            self._database_client = self._cosmos_client.delete_database(
-                self._database_client
-            )
-        self._container_client = None
-
     def _create_container(self) -> None:
-        """Create a container for the current container name if it doesn't exist."""
         partition_key = PartitionKey(path="/id", kind="Hash")
         if self._database_client:
             self._container_client = (
@@ -118,319 +111,216 @@ class AzureCosmosStorage(Storage):
                 )
             )
 
-    def _delete_container(self) -> None:
-        """Delete the container with the current container name if it exists."""
-        if self._database_client and self._container_client:
-            self._container_client = self._database_client.delete_container(
-                self._container_client
-            )
+    def _namespaced_key(self, key: str) -> str:
+        """Prefix *key* with the current namespace (if any).
 
-    def find(
-        self,
-        file_pattern: re.Pattern[str],
-    ) -> Iterator[str]:
-        """Find documents in a Cosmos DB container using a file pattern regex.
-
-        Params:
-            file_pattern: The file pattern to use.
-
-        Returns
-        -------
-            An iterator of document IDs and their corresponding regex matches.
+        Uses ``:`` as separator because Cosmos DB document ids cannot
+        contain ``/`` (it is interpreted as a path separator in the REST API).
         """
-        logger.info(
-            "Search container [%s] for documents matching [%s]",
-            self._container_name,
-            file_pattern.pattern,
-        )
-        if not self._database_client or not self._container_client:
+        return f"{self._namespace}:{key}" if self._namespace else key
+
+    # ------------------------------------------------------------------
+    # Storage interface
+    # ------------------------------------------------------------------
+
+    def find(self, file_pattern: re.Pattern[str]) -> Iterator[str]:
+        """Find documents whose id matches *file_pattern*."""
+        if not self._container_client:
             return
 
+        query = "SELECT c.id FROM c WHERE RegexMatch(c.id, @pattern)"
+        parameters: list[dict[str, Any]] = [
+            {"name": "@pattern", "value": file_pattern.pattern},
+        ]
         try:
-            query = "SELECT * FROM c WHERE RegexMatch(c.id, @pattern)"
-            parameters: list[dict[str, Any]] = [
-                {"name": "@pattern", "value": file_pattern.pattern}
-            ]
-
-            items = self._query_all_items(
-                self._container_client,
-                query=query,
-                parameters=parameters,
+            items = list(
+                self._container_client.query_items(
+                    query=query,
+                    parameters=parameters,
+                    enable_cross_partition_query=True,
+                )
             )
-            logger.debug("All items: %s", [item["id"] for item in items])
-            num_loaded = 0
-            num_total = len(items)
-            if num_total == 0:
-                return
-            num_filtered = 0
             for item in items:
-                match = file_pattern.search(item["id"])
-                if match:
+                if file_pattern.search(item["id"]):
                     yield item["id"]
-                    num_loaded += 1
-                else:
-                    num_filtered += 1
-
-            progress_status = _create_progress_status(
-                num_loaded, num_filtered, num_total
-            )
-            logger.debug(
-                "Progress: %s (%d/%d completed)",
-                progress_status.description,
-                progress_status.completed_items,
-                progress_status.total_items,
-            )
         except Exception:  # noqa: BLE001
-            logger.warning(
-                "An error occurred while searching for documents in Cosmos DB."
-            )
+            logger.warning("Error searching Cosmos DB for pattern %s", file_pattern.pattern)
 
     async def get(
         self, key: str, as_bytes: bool | None = None, encoding: str | None = None
     ) -> Any:
-        """Fetch all items in a container that match the given key."""
+        """Get the value for *key*.
+
+        Returns the JSON-decoded body as a string.  If *as_bytes* is True,
+        returns UTF-8 encoded bytes of the JSON body.
+        """
+        if not self._container_client:
+            return None
+        namespaced = self._namespaced_key(key)
         try:
-            if not self._database_client or not self._container_client:
-                return None
-
+            item = self._container_client.read_item(
+                item=namespaced, partition_key=namespaced
+            )
+            body = item.get("body")
+            result = json.dumps(body) if not isinstance(body, str) else body
             if as_bytes:
-                prefix = self._get_prefix(key)
-                query = f"SELECT * FROM c WHERE STARTSWITH(c.id, '{prefix}:')"  # noqa: S608
-                items_list = self._query_all_items(
-                    self._container_client,
-                    query=query,
-                )
-
-                logger.info("Cosmos load prefix=%s count=%d", prefix, len(items_list))
-
-                if not items_list:
-                    logger.warning("No items found for prefix %s (key=%s)", prefix, key)
-                    return None
-
-                for item in items_list:
-                    item["id"] = item["id"].split(":", 1)[1]
-
-                items_json_str = json.dumps(items_list)
-                items_df = pd.read_json(
-                    StringIO(items_json_str), orient="records", lines=False
-                )
-
-                if prefix == "entities":
-                    # Always preserve the Cosmos suffix for debugging/migrations
-                    items_df["cosmos_id"] = items_df["id"]
-                    items_df["id"] = items_df["id"].astype(
-                        str
-                    )  # Only restore pipeline UUID id if we actually have it
-
-                    if "human_readable_id" in items_df.columns:
-                        # Fill any NaN values before converting to int
-                        items_df["human_readable_id"] = (
-                            items_df["human_readable_id"]
-                            .fillna(items_df["id"])
-                            .astype(int)
-                        )
-                    else:
-                        # Fresh run case: extract_graph entities may not have entity_id yet
-                        # Keep id as the suffix (stable_key/index) for now.
-                        logger.info(
-                            "Entities loaded without entity_id; leaving id as cosmos suffix."
-                        )
-
-                if items_df.empty:
-                    logger.warning(
-                        "No rows returned for prefix %s (key=%s)", prefix, key
-                    )
-                    return None
-                return items_df.to_parquet()
-            item = self._container_client.read_item(item=key, partition_key=key)
-            item_body = item.get("body")
-            return json.dumps(item_body)
+                return result.encode(encoding or self._encoding)
+            return result
+        except CosmosResourceNotFoundError:
+            return None
         except Exception:
-            logger.exception("Error reading item %s", key)
+            logger.exception("Error reading item %s", namespaced)
             return None
 
     async def set(self, key: str, value: Any, encoding: str | None = None) -> None:
-        """Write an item to Cosmos DB. If the value is bytes, we assume it's a parquet file and we write each row as a separate item with id formatted as {prefix}:{stable_key_or_index}."""
-        if not self._database_client or not self._container_client:
-            error_msg = "Database or container not initialized. Cannot write item."
-            raise ValueError(error_msg)
+        """Store *value* under *key*.
+
+        *value* should be a JSON string. It is parsed and stored under the
+        ``body`` field so that Cosmos indexes it as structured data.
+        """
+        if not self._container_client:
+            msg = "Container not initialized."
+            raise ValueError(msg)
+        namespaced = self._namespaced_key(key)
         try:
-            if isinstance(value, bytes):
-                prefix = self._get_prefix(key)
-                value_df = pd.read_parquet(BytesIO(value))
-
-                # Decide once per dataframe
-                df_has_id = "id" in value_df.columns
-
-                # IMPORTANT: if we now have ids, undo the earlier "no id" marking
-                if df_has_id:
-                    self._no_id_prefixes.discard(prefix)
-                else:
-                    self._no_id_prefixes.add(prefix)
-
-                cosmosdb_item_list = json.loads(
-                    value_df.to_json(orient="records", lines=False, force_ascii=False)
-                )
-
-                for index, cosmosdb_item in enumerate(cosmosdb_item_list):
-                    if prefix == "entities":
-                        # Stable key for Cosmos identity
-                        stable_key = cosmosdb_item.get("human_readable_id", index)
-                        cosmos_id = f"{prefix}:{stable_key}"
-
-                        # If the pipeline provided a final UUID, store it separately
-                        if "id" in cosmosdb_item:
-                            cosmosdb_item["entity_id"] = cosmosdb_item["id"]
-
-                        # Cosmos identity must be stable and NEVER change
-                        cosmosdb_item["id"] = cosmos_id
-
-                    else:
-                        # Original behavior for non-entity prefixes
-                        if df_has_id:
-                            cosmosdb_item["id"] = f"{prefix}:{cosmosdb_item['id']}"
-                        else:
-                            cosmosdb_item["id"] = f"{prefix}:{index}"
-
-                    self._container_client.upsert_item(body=cosmosdb_item)
+            # Parse JSON strings so the body is queryable; store others as-is.
+            if isinstance(value, str):
+                try:
+                    parsed = json.loads(value)
+                except (json.JSONDecodeError, ValueError):
+                    parsed = value
+            elif isinstance(value, bytes):
+                parsed = value.decode(encoding or self._encoding)
             else:
-                cosmosdb_item = {"id": key, "body": json.loads(value)}
-                self._container_client.upsert_item(body=cosmosdb_item)
-
+                parsed = value
+            cosmosdb_item = {"id": namespaced, "body": parsed}
+            self._container_client.upsert_item(body=cosmosdb_item)
         except Exception:
-            logger.exception("Error writing item %s", key)
+            logger.exception("Error writing item %s", namespaced)
 
     async def has(self, key: str) -> bool:
-        """Check if the contents of the given filename key exist in the cosmosdb storage."""
-        if not self._database_client or not self._container_client:
+        """Return True if *key* exists."""
+        if not self._container_client:
             return False
-        if ".parquet" in key:
-            prefix = self._get_prefix(key)
-            count = self._query_count(
-                self._container_client,
-                query_filter=f"STARTSWITH(c.id, '{prefix}:')",
+        namespaced = self._namespaced_key(key)
+        try:
+            self._container_client.read_item(
+                item=namespaced, partition_key=namespaced
             )
-            return count > 0
-        count = self._query_count(
-            self._container_client,
-            query_filter=f"c.id = '{key}'",
-        )
-        return count >= 1
-
-    def _query_all_items(
-        self,
-        container_client: ContainerProxy,
-        query: str,
-        parameters: list[dict[str, Any]] | None = None,
-        page_size: int = _DEFAULT_PAGE_SIZE,
-    ) -> list[dict[str, Any]]:
-        """Fetch all items from a Cosmos DB query using pagination.
-
-        This avoids the pitfalls of calling list() on the full pager, which can
-        time out or return incomplete results for large result sets.
-        """
-        results: list[dict[str, Any]] = []
-        query_kwargs: dict[str, Any] = {
-            "query": query,
-            "enable_cross_partition_query": True,
-            "max_item_count": page_size,
-        }
-        if parameters:
-            query_kwargs["parameters"] = parameters
-
-        pager = container_client.query_items(**query_kwargs).by_page()
-        for page in pager:
-            results.extend(page)
-        return results
-
-    def _query_count(
-        self,
-        container_client: ContainerProxy,
-        query_filter: str,
-        parameters: list[dict[str, Any]] | None = None,
-    ) -> int:
-        """Return the count of items matching a filter, without fetching them all.
-
-        Parameters
-        ----------
-        query_filter:
-            The WHERE clause (without 'WHERE'), e.g. "STARTSWITH(c.id, 'entities:')".
-        """
-        count_query = f"SELECT VALUE COUNT(1) FROM c WHERE {query_filter}"  # noqa: S608
-        query_kwargs: dict[str, Any] = {
-            "query": count_query,
-            "enable_cross_partition_query": True,
-        }
-        if parameters:
-            query_kwargs["parameters"] = parameters
-
-        results = list(container_client.query_items(**query_kwargs))
-        return int(results[0]) if results else 0  # type: ignore[arg-type]
+            return True
+        except CosmosResourceNotFoundError:
+            return False
+        except Exception:
+            logger.exception("Error checking item %s", namespaced)
+            return False
 
     async def delete(self, key: str) -> None:
-        """Delete all cosmosdb items belonging to the given filename key."""
-        if not self._database_client or not self._container_client:
+        """Delete *key*."""
+        if not self._container_client:
             return
+        namespaced = self._namespaced_key(key)
         try:
-            if ".parquet" in key:
-                prefix = self._get_prefix(key)
-                query = f"SELECT * FROM c WHERE STARTSWITH(c.id, '{prefix}:')"  # noqa: S608
-                items = self._query_all_items(
-                    self._container_client,
-                    query=query,
-                )
-                for item in items:
-                    self._container_client.delete_item(
-                        item=item["id"], partition_key=item["id"]
-                    )
-            else:
-                self._container_client.delete_item(item=key, partition_key=key)
+            self._container_client.delete_item(
+                item=namespaced, partition_key=namespaced
+            )
         except CosmosResourceNotFoundError:
             return
         except Exception:
-            logger.exception("Error deleting item %s", key)
+            logger.exception("Error deleting item %s", namespaced)
 
     async def clear(self) -> None:
-        """Clear all contents from storage.
+        """Delete all items in the current namespace.
 
-        # This currently deletes the database, including all containers and data within it.
-        # TODO: We should decide what granularity of deletion is the ideal behavior (e.g. delete all items within a container, delete the current container, delete the current database)
+        If no namespace is set, deletes the entire container and recreates it.
         """
-        self._delete_database()
+        if not self._container_client or not self._database_client:
+            return
+
+        if not self._namespace:
+            # Root storage: drop and recreate the container.
+            self._database_client.delete_container(self._container_client)
+            self._container_client = None
+            self._create_container()
+        else:
+            # Namespaced: delete items matching the namespace prefix.
+            query = "SELECT c.id FROM c WHERE STARTSWITH(c.id, @prefix)"
+            parameters: list[dict[str, Any]] = [
+                {"name": "@prefix", "value": f"{self._namespace}:"},
+            ]
+            items = list(
+                self._container_client.query_items(
+                    query=query,
+                    parameters=parameters,
+                    enable_cross_partition_query=True,
+                )
+            )
+            for item in items:
+                try:
+                    self._container_client.delete_item(
+                        item=item["id"], partition_key=item["id"]
+                    )
+                except CosmosResourceNotFoundError:
+                    pass
+
+    def child(self, name: str | None) -> "AzureCosmosStorage":
+        """Create a child storage with an extended namespace prefix.
+
+        Uses ``:`` as the namespace separator (``/`` is illegal in Cosmos IDs).
+        """
+        if name is None:
+            return self
+        child_ns = f"{self._namespace}:{name}" if self._namespace else name
+        child = AzureCosmosStorage.__new__(AzureCosmosStorage)
+        child._cosmos_client = self._cosmos_client
+        child._database_client = self._database_client
+        child._container_client = self._container_client
+        child._database_name = self._database_name
+        child._connection_string = self._connection_string
+        child._cosmosdb_account_url = self._cosmosdb_account_url
+        child._container_name = self._container_name
+        child._encoding = self._encoding
+        child._namespace = child_ns
+        return child
 
     def keys(self) -> list[str]:
-        """Return the keys in the storage."""
-        msg = "CosmosDB storage does yet not support listing keys."
-        raise NotImplementedError(msg)
+        """List all keys in the current namespace."""
+        if not self._container_client:
+            return []
+        if self._namespace:
+            query = "SELECT c.id FROM c WHERE STARTSWITH(c.id, @prefix)"
+            parameters: list[dict[str, Any]] = [
+                {"name": "@prefix", "value": f"{self._namespace}:"},
+            ]
+            items = list(
+                self._container_client.query_items(
+                    query=query,
+                    parameters=parameters,
+                    enable_cross_partition_query=True,
+                )
+            )
+            prefix_len = len(self._namespace) + 1  # +1 for ':'
+            return [item["id"][prefix_len:] for item in items]
 
-    def child(self, name: str | None) -> "Storage":
-        """Create a child storage instance."""
-        return self
-
-    def _get_prefix(self, key: str) -> str:
-        """Get the prefix of the filename key."""
-        return key.split(".")[0]
+        items = list(
+            self._container_client.query_items(
+                query="SELECT c.id FROM c",
+                enable_cross_partition_query=True,
+            )
+        )
+        return [item["id"] for item in items]
 
     async def get_creation_date(self, key: str) -> str:
-        """Get a value from the cache."""
+        """Get the creation date for *key* from the Cosmos ``_ts`` field."""
+        if not self._container_client:
+            return ""
+        namespaced = self._namespaced_key(key)
         try:
-            if not self._database_client or not self._container_client:
-                return ""
-            item = self._container_client.read_item(item=key, partition_key=key)
+            item = self._container_client.read_item(
+                item=namespaced, partition_key=namespaced
+            )
             return get_timestamp_formatted_with_local_tz(
                 datetime.fromtimestamp(item["_ts"], tz=timezone.utc)
             )
-
         except Exception:  # noqa: BLE001
-            logger.warning("Error getting key %s", key)
+            logger.warning("Error getting creation date for %s", namespaced)
             return ""
-
-
-def _create_progress_status(
-    num_loaded: int, num_filtered: int, num_total: int
-) -> Progress:
-    return Progress(
-        total_items=num_total,
-        completed_items=num_loaded + num_filtered,
-        description=f"{num_loaded} files loaded ({num_filtered} filtered)",
-    )

--- a/packages/graphrag-storage/graphrag_storage/azure_cosmos_storage.py
+++ b/packages/graphrag-storage/graphrag_storage/azure_cosmos_storage.py
@@ -10,6 +10,7 @@ snapshots, and LLM cache entries.
 Tabular data (DataFrames / parquet) should use CosmosTableProvider instead.
 """
 
+import contextlib
 import json
 import logging
 import re
@@ -144,7 +145,9 @@ class AzureCosmosStorage(Storage):
                 if file_pattern.search(item["id"]):
                     yield item["id"]
         except Exception:  # noqa: BLE001
-            logger.warning("Error searching Cosmos DB for pattern %s", file_pattern.pattern)
+            logger.warning(
+                "Error searching Cosmos DB for pattern %s", file_pattern.pattern
+            )
 
     async def get(
         self, key: str, as_bytes: bool | None = None, encoding: str | None = None
@@ -163,14 +166,15 @@ class AzureCosmosStorage(Storage):
             )
             body = item.get("body")
             result = json.dumps(body) if not isinstance(body, str) else body
-            if as_bytes:
-                return result.encode(encoding or self._encoding)
-            return result
         except CosmosResourceNotFoundError:
             return None
         except Exception:
             logger.exception("Error reading item %s", namespaced)
             return None
+        else:
+            if as_bytes:
+                return result.encode(encoding or self._encoding)
+            return result
 
     async def set(self, key: str, value: Any, encoding: str | None = None) -> None:
         """Store *value* under *key*.
@@ -204,15 +208,14 @@ class AzureCosmosStorage(Storage):
             return False
         namespaced = self._namespaced_key(key)
         try:
-            self._container_client.read_item(
-                item=namespaced, partition_key=namespaced
-            )
-            return True
+            self._container_client.read_item(item=namespaced, partition_key=namespaced)
         except CosmosResourceNotFoundError:
             return False
         except Exception:
             logger.exception("Error checking item %s", namespaced)
             return False
+        else:
+            return True
 
     async def delete(self, key: str) -> None:
         """Delete *key*."""
@@ -255,12 +258,10 @@ class AzureCosmosStorage(Storage):
                 )
             )
             for item in items:
-                try:
+                with contextlib.suppress(CosmosResourceNotFoundError):
                     self._container_client.delete_item(
                         item=item["id"], partition_key=item["id"]
                     )
-                except CosmosResourceNotFoundError:
-                    pass
 
     def child(self, name: str | None) -> "AzureCosmosStorage":
         """Create a child storage with an extended namespace prefix.
@@ -270,17 +271,14 @@ class AzureCosmosStorage(Storage):
         if name is None:
             return self
         child_ns = f"{self._namespace}:{name}" if self._namespace else name
-        child = AzureCosmosStorage.__new__(AzureCosmosStorage)
-        child._cosmos_client = self._cosmos_client
-        child._database_client = self._database_client
-        child._container_client = self._container_client
-        child._database_name = self._database_name
-        child._connection_string = self._connection_string
-        child._cosmosdb_account_url = self._cosmosdb_account_url
-        child._container_name = self._container_name
-        child._encoding = self._encoding
-        child._namespace = child_ns
-        return child
+        return AzureCosmosStorage(
+            database_name=self._database_name,
+            container_name=self._container_name,
+            connection_string=self._connection_string,
+            account_url=self._cosmosdb_account_url,
+            encoding=self._encoding,
+            namespace=child_ns,
+        )
 
     def keys(self) -> list[str]:
         """List all keys in the current namespace."""

--- a/packages/graphrag-storage/graphrag_storage/tables/cosmos_table.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/cosmos_table.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""Cosmos DB implementation of the Table abstraction for streaming row access."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import TYPE_CHECKING, Any
+
+from graphrag_storage.tables.table import RowTransformer, Table
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from azure.cosmos.aio import ContainerProxy
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PAGE_SIZE = 100
+
+
+def _identity(row: dict[str, Any]) -> Any:
+    """Return row unchanged (default transformer)."""
+    return row
+
+
+def _apply_transformer(transformer: RowTransformer, row: dict[str, Any]) -> Any:
+    """Apply transformer, handling both callables and classes (e.g. Pydantic models)."""
+    if inspect.isclass(transformer):
+        return transformer(**row)
+    return transformer(row)
+
+
+# Cosmos system properties to strip from returned rows.
+_COSMOS_SYSTEM_KEYS = frozenset({
+    "_rid",
+    "_self",
+    "_etag",
+    "_attachments",
+    "_ts",
+    "namespace",
+    "table_name",
+})
+
+
+def _strip_cosmos_metadata(doc: dict[str, Any]) -> dict[str, Any]:
+    """Remove Cosmos system properties and internal fields from a document."""
+    return {k: v for k, v in doc.items() if k not in _COSMOS_SYSTEM_KEYS}
+
+
+class CosmosTable(Table):
+    """Streaming table interface backed by Cosmos DB.
+
+    Reads page through query_items() using the async SDK, yielding rows
+    one at a time.  Writes accumulate in memory and are bulk-upserted on
+    close().
+    """
+
+    def __init__(
+        self,
+        container: ContainerProxy,
+        table_name: str,
+        namespace: str,
+        transformer: RowTransformer | None = None,
+        truncate: bool = True,
+        page_size: int = _DEFAULT_PAGE_SIZE,
+    ) -> None:
+        """Initialise with a Cosmos container and table/namespace identifiers."""
+        self._container = container
+        self._table_name = table_name
+        self._namespace = namespace
+        self._transformer = transformer or _identity
+        self._truncate = truncate
+        self._page_size = page_size
+        self._write_rows: list[dict[str, Any]] = []
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        return self._aiter_impl()
+
+    async def _aiter_impl(self) -> AsyncIterator[Any]:
+        """Page through Cosmos query results, yielding transformed rows."""
+        query = "SELECT * FROM c WHERE c.table_name = @table_name"
+        parameters: list[dict[str, Any]] = [
+            {"name": "@table_name", "value": self._table_name},
+        ]
+        async for page in self._container.query_items(
+            query=query,
+            parameters=parameters,
+            partition_key=self._namespace,
+            max_item_count=self._page_size,
+        ).by_page():
+            async for doc in page:
+                row = _strip_cosmos_metadata(doc)
+                yield _apply_transformer(self._transformer, row)
+
+    async def length(self) -> int:
+        """Return the number of rows in the table (single-partition COUNT)."""
+        query = "SELECT VALUE COUNT(1) FROM c WHERE c.table_name = @table_name"
+        parameters: list[dict[str, Any]] = [
+            {"name": "@table_name", "value": self._table_name},
+        ]
+        results: list[Any] = []
+        async for item in self._container.query_items(
+            query=query,
+            parameters=parameters,
+            partition_key=self._namespace,
+        ):
+            results.append(item)
+        return int(results[0]) if results else 0
+
+    async def has(self, row_id: str) -> bool:
+        """Check if a row with the given ID exists (point-read)."""
+        cosmos_id = f"{self._table_name}:{row_id}"
+        try:
+            await self._container.read_item(
+                item=cosmos_id, partition_key=self._namespace
+            )
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    async def write(self, row: dict[str, Any]) -> None:
+        """Accumulate a row for batch upsert on close()."""
+        self._write_rows.append(row)
+
+    async def close(self) -> None:
+        """Flush accumulated rows to Cosmos DB.
+
+        If truncate=True, existing documents for this table in the namespace
+        are deleted before writing.
+        """
+        if self._truncate and self._write_rows:
+            await self._delete_table_docs()
+
+        for index, row in enumerate(self._write_rows):
+            doc = dict(row)
+            row_key = doc.pop("id", index)
+            doc["id"] = f"{self._table_name}:{row_key}"
+            doc["namespace"] = self._namespace
+            doc["table_name"] = self._table_name
+            if row_key != doc["id"]:
+                doc["row_id"] = row_key
+            await self._container.upsert_item(body=doc)
+
+        self._write_rows = []
+
+    async def _delete_table_docs(self) -> None:
+        """Delete all documents for this table in the current namespace."""
+        query = "SELECT c.id FROM c WHERE c.table_name = @table_name"
+        parameters: list[dict[str, Any]] = [
+            {"name": "@table_name", "value": self._table_name},
+        ]
+        async for page in self._container.query_items(
+            query=query,
+            parameters=parameters,
+            partition_key=self._namespace,
+        ).by_page():
+            async for doc in page:
+                await self._container.delete_item(
+                    item=doc["id"], partition_key=self._namespace
+                )

--- a/packages/graphrag-storage/graphrag_storage/tables/cosmos_table.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/cosmos_table.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _DEFAULT_PAGE_SIZE = 100
+_DEFAULT_BATCH_SIZE = 50
 
 
 def _identity(row: dict[str, Any]) -> Any:
@@ -66,6 +67,7 @@ class CosmosTable(Table):
         transformer: RowTransformer | None = None,
         truncate: bool = True,
         page_size: int = _DEFAULT_PAGE_SIZE,
+        batch_size: int = _DEFAULT_BATCH_SIZE,
     ) -> None:
         """Initialise with a Cosmos container and table/namespace identifiers."""
         self._container = container
@@ -74,6 +76,7 @@ class CosmosTable(Table):
         self._transformer = transformer or _identity
         self._truncate = truncate
         self._page_size = page_size
+        self._batch_size = batch_size
         self._write_rows: list[dict[str, Any]] = []
 
     # ------------------------------------------------------------------
@@ -142,6 +145,7 @@ class CosmosTable(Table):
         if self._truncate and self._write_rows:
             await self._delete_table_docs()
 
+        docs = []
         for index, row in enumerate(self._write_rows):
             doc = dict(row)
             row_key = doc.pop("id", index)
@@ -150,7 +154,16 @@ class CosmosTable(Table):
             doc["table_name"] = self._table_name
             if row_key != doc["id"]:
                 doc["row_id"] = row_key
-            await self._container.upsert_item(body=doc)
+            docs.append(doc)
+
+        if docs:
+            from graphrag_storage.tables.cosmos_table_provider import (
+                _batch_upsert,
+            )
+
+            await _batch_upsert(
+                self._container, docs, self._namespace, self._batch_size
+            )
 
         self._write_rows = []
 

--- a/packages/graphrag-storage/graphrag_storage/tables/cosmos_table.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/cosmos_table.py
@@ -9,6 +9,8 @@ import inspect
 import logging
 from typing import TYPE_CHECKING, Any
 
+from azure.cosmos.exceptions import CosmosResourceNotFoundError
+
 from graphrag_storage.tables.table import RowTransformer, Table
 
 if TYPE_CHECKING:
@@ -47,8 +49,12 @@ _COSMOS_SYSTEM_KEYS = frozenset({
 
 
 def _strip_cosmos_metadata(doc: dict[str, Any]) -> dict[str, Any]:
-    """Remove Cosmos system properties and internal fields from a document."""
-    return {k: v for k, v in doc.items() if k not in _COSMOS_SYSTEM_KEYS}
+    """Remove Cosmos system properties and restore original id."""
+    result = {k: v for k, v in doc.items() if k not in _COSMOS_SYSTEM_KEYS}
+    # Restore the pipeline's original id from row_id if present.
+    if "row_id" in result:
+        result["id"] = result.pop("row_id")
+    return result
 
 
 class CosmosTable(Table):
@@ -125,7 +131,7 @@ class CosmosTable(Table):
             await self._container.read_item(
                 item=cosmos_id, partition_key=self._namespace
             )
-        except Exception:  # noqa: BLE001
+        except CosmosResourceNotFoundError:
             return False
         else:
             return True
@@ -154,8 +160,7 @@ class CosmosTable(Table):
             doc["id"] = f"{self._table_name}:{row_key}"
             doc["namespace"] = self._namespace
             doc["table_name"] = self._table_name
-            if row_key != doc["id"]:
-                doc["row_id"] = row_key
+            doc["row_id"] = row_key
             docs.append(doc)
 
         if docs:

--- a/packages/graphrag-storage/graphrag_storage/tables/cosmos_table.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/cosmos_table.py
@@ -84,6 +84,7 @@ class CosmosTable(Table):
     # ------------------------------------------------------------------
 
     def __aiter__(self) -> AsyncIterator[Any]:
+        """Iterate rows asynchronously."""
         return self._aiter_impl()
 
     async def _aiter_impl(self) -> AsyncIterator[Any]:
@@ -114,7 +115,7 @@ class CosmosTable(Table):
             parameters=parameters,
             partition_key=self._namespace,
         ):
-            results.append(item)
+            results.append(item)  # noqa: PERF401
         return int(results[0]) if results else 0
 
     async def has(self, row_id: str) -> bool:
@@ -124,9 +125,10 @@ class CosmosTable(Table):
             await self._container.read_item(
                 item=cosmos_id, partition_key=self._namespace
             )
-            return True
         except Exception:  # noqa: BLE001
             return False
+        else:
+            return True
 
     # ------------------------------------------------------------------
     # Write

--- a/packages/graphrag-storage/graphrag_storage/tables/cosmos_table_provider.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/cosmos_table_provider.py
@@ -1,0 +1,453 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""Cosmos DB native table provider implementation.
+
+Stores each DataFrame row as a Cosmos document, eliminating the
+parquet serialisation round-trip used by ParquetTableProvider.
+
+Container schema
+----------------
+Partition key : /namespace
+Document id   : {table_name}:{row_key}
+
+Every document carries two internal fields used for routing:
+    namespace  – partition key, set by child() hierarchy
+    table_name – discriminator for per-table queries
+
+All queries target a single namespace partition (no cross-partition fan-out).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import pandas as pd
+from azure.cosmos.aio import ContainerProxy, CosmosClient, DatabaseProxy
+from azure.cosmos.partition_key import PartitionKey
+from azure.identity.aio import DefaultAzureCredential
+
+from graphrag_storage.tables.cosmos_table import (
+    CosmosTable,
+    _strip_cosmos_metadata,
+)
+from graphrag_storage.tables.table import RowTransformer, Table
+from graphrag_storage.tables.table_provider import TableProvider
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PAGE_SIZE = 100
+
+# Cosmos system / internal fields to exclude from DataFrame columns.
+_INTERNAL_FIELDS = frozenset({
+    "_rid",
+    "_self",
+    "_etag",
+    "_attachments",
+    "_ts",
+    "namespace",
+    "table_name",
+})
+
+
+class CosmosTableProvider(TableProvider):
+    """TableProvider backed by Azure Cosmos DB (NoSQL API, async SDK).
+
+    Each table is stored as a set of documents within a single container,
+    discriminated by the ``table_name`` field.  Namespace isolation (used
+    by the update pipeline's delta / previous split) is achieved via the
+    ``/namespace`` partition key.
+    """
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    def __init__(
+        self,
+        *,
+        connection_string: str | None = None,
+        account_url: str | None = None,
+        database_name: str | None = None,
+        container_name: str | None = None,
+        namespace: str = "",
+        legacy_container: str | None = None,
+        # Allow pre-built internals for child() and testing.
+        _cosmos_client: CosmosClient | None = None,
+        _container: ContainerProxy | None = None,
+        _legacy_container: ContainerProxy | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if _container is not None:
+            # Fast path: child() or test injection.
+            self._cosmos_client = _cosmos_client
+            self._container = _container
+            self._legacy_container = _legacy_container
+            self._namespace = namespace
+            self._owns_client = False
+            return
+
+        # Normal construction from config values.
+        if not database_name:
+            msg = "CosmosTableProvider requires 'database_name'."
+            raise ValueError(msg)
+        if not container_name:
+            msg = "CosmosTableProvider requires 'container_name'."
+            raise ValueError(msg)
+        if connection_string and account_url:
+            msg = "Specify either 'connection_string' or 'account_url', not both."
+            raise ValueError(msg)
+        if not connection_string and not account_url:
+            msg = "CosmosTableProvider requires 'connection_string' or 'account_url'."
+            raise ValueError(msg)
+
+        if connection_string:
+            self._cosmos_client = CosmosClient.from_connection_string(
+                connection_string
+            )
+        else:
+            self._cosmos_client = CosmosClient(
+                url=account_url,  # type: ignore[arg-type]
+                credential=DefaultAzureCredential(),
+            )
+
+        self._namespace = namespace
+        self._owns_client = True
+
+        # Containers are created lazily on first use via _ensure_container().
+        self._database_name = database_name
+        self._container_name = container_name
+        self._legacy_container_name = legacy_container
+        self._container: ContainerProxy | None = None  # type: ignore[assignment]
+        self._legacy_container: ContainerProxy | None = None
+
+    # ------------------------------------------------------------------
+    # Lazy initialisation (async work we can't do in __init__)
+    # ------------------------------------------------------------------
+
+    async def _ensure_container(self) -> ContainerProxy:
+        """Return the container proxy, creating DB / container on first call."""
+        if self._container is not None:
+            return self._container
+
+        db: DatabaseProxy = (
+            await self._cosmos_client.create_database_if_not_exists(  # type: ignore[union-attr]
+                id=self._database_name
+            )
+        )
+        self._container = await db.create_container_if_not_exists(
+            id=self._container_name,
+            partition_key=PartitionKey(path="/namespace", kind="Hash"),
+        )
+
+        if self._legacy_container_name:
+            # Legacy container already exists — just get a reference.
+            self._legacy_container = db.get_container_client(
+                self._legacy_container_name
+            )
+
+        return self._container
+
+    # ------------------------------------------------------------------
+    # TableProvider interface
+    # ------------------------------------------------------------------
+
+    async def read_dataframe(self, table_name: str) -> pd.DataFrame:
+        """Read all rows for *table_name* within the current namespace."""
+        container = await self._ensure_container()
+
+        query = "SELECT * FROM c WHERE c.table_name = @table_name"
+        parameters: list[dict[str, Any]] = [
+            {"name": "@table_name", "value": table_name},
+        ]
+
+        docs: list[dict[str, Any]] = []
+        async for page in container.query_items(
+            query=query,
+            parameters=parameters,
+            partition_key=self._namespace,
+            max_item_count=_DEFAULT_PAGE_SIZE,
+        ).by_page():
+            async for doc in page:
+                docs.append(_strip_cosmos_metadata(doc))
+
+        if docs:
+            return pd.DataFrame(docs)
+
+        # ---- Legacy fallback (optional) --------------------------------
+        if self._legacy_container is not None:
+            df = await self._read_legacy_table(table_name)
+            if df is not None and not df.empty:
+                logger.warning(
+                    "Reading '%s' from legacy container — run "
+                    "'graphrag migrate-cosmos' to complete migration.",
+                    table_name,
+                )
+                return df
+
+        msg = f"Table '{table_name}' not found in namespace '{self._namespace}'."
+        raise ValueError(msg)
+
+    async def write_dataframe(self, table_name: str, df: pd.DataFrame) -> None:
+        """Write *df* as documents, replacing any existing rows for this table."""
+        container = await self._ensure_container()
+
+        # Delete existing documents for this table in the namespace.
+        await self._delete_table(container, table_name)
+
+        records = json.loads(
+            df.to_json(orient="records", lines=False, force_ascii=False)
+        )
+        for index, row in enumerate(records):
+            row_key = row.pop("id", index)
+            doc = {
+                "id": f"{table_name}:{row_key}",
+                "namespace": self._namespace,
+                "table_name": table_name,
+                **row,
+            }
+            # Preserve the pipeline's id value so it round-trips.
+            if "id" in df.columns:
+                doc["row_id"] = row_key
+            await container.upsert_item(body=doc)
+
+    async def has(self, table_name: str) -> bool:
+        """Check whether any documents exist for *table_name*."""
+        container = await self._ensure_container()
+        query = (
+            "SELECT VALUE COUNT(1) FROM c WHERE c.table_name = @table_name"
+        )
+        parameters: list[dict[str, Any]] = [
+            {"name": "@table_name", "value": table_name},
+        ]
+        results: list[Any] = []
+        async for item in container.query_items(
+            query=query,
+            parameters=parameters,
+            partition_key=self._namespace,
+        ):
+            results.append(item)
+        if results and results[0] > 0:
+            return True
+
+        # Fallback: check legacy container.
+        if self._legacy_container is not None:
+            return await self._legacy_table_exists(table_name)
+        return False
+
+    def list(self) -> list[str]:
+        """List all table names in the current namespace.
+
+        Note: this method is synchronous in the ABC. We run a sync wrapper
+        over the async query. Callers that need pure-async should use
+        ``list_async()`` instead.
+        """
+        import asyncio
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            # We're inside an async context — create a task via a helper.
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                return pool.submit(asyncio.run, self._list_async()).result()
+        return asyncio.run(self._list_async())
+
+    async def _list_async(self) -> list[str]:
+        """Async implementation of list()."""
+        container = await self._ensure_container()
+        query = "SELECT DISTINCT VALUE c.table_name FROM c"
+        names: list[Any] = []
+        async for item in container.query_items(
+            query=query,
+            partition_key=self._namespace,
+        ):
+            names.append(item)
+        return names
+
+    def open(
+        self,
+        table_name: str,
+        transformer: RowTransformer | None = None,
+        truncate: bool = True,
+    ) -> Table:
+        """Open a table for streaming row-by-row access."""
+        # _ensure_container() is async; CosmosTable will need the container.
+        # We use a lazy pattern: pass self so the table can call _ensure_container.
+        return _LazyCosmosTable(
+            provider=self,
+            table_name=table_name,
+            transformer=transformer,
+            truncate=truncate,
+        )
+
+    # ------------------------------------------------------------------
+    # child() — namespace isolation
+    # ------------------------------------------------------------------
+
+    def child(self, name: str | None) -> "CosmosTableProvider":
+        """Create a child provider with an extended namespace."""
+        if name is None:
+            return self
+        child_ns = f"{self._namespace}/{name}" if self._namespace else name
+        return CosmosTableProvider(
+            _cosmos_client=self._cosmos_client,
+            _container=self._container,
+            _legacy_container=self._legacy_container,
+            namespace=child_ns,
+        )
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    async def close(self) -> None:
+        """Close the underlying Cosmos client if we own it."""
+        if self._owns_client and self._cosmos_client is not None:
+            await self._cosmos_client.close()
+            self._cosmos_client = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _delete_table(
+        self, container: ContainerProxy, table_name: str
+    ) -> None:
+        """Delete all documents for a table in the current namespace."""
+        query = "SELECT c.id FROM c WHERE c.table_name = @table_name"
+        parameters: list[dict[str, Any]] = [
+            {"name": "@table_name", "value": table_name},
+        ]
+        async for page in container.query_items(
+            query=query,
+            parameters=parameters,
+            partition_key=self._namespace,
+        ).by_page():
+            async for doc in page:
+                await container.delete_item(
+                    item=doc["id"], partition_key=self._namespace
+                )
+
+    # ------------------------------------------------------------------
+    # Legacy fallback reads
+    # ------------------------------------------------------------------
+
+    async def _read_legacy_table(self, table_name: str) -> pd.DataFrame | None:
+        """Read from the old AzureCosmosStorage container (partition key /id).
+
+        Legacy documents have id = "{prefix}:{key}" and no namespace/table_name
+        fields.  Entity documents have the pipeline id renamed to entity_id.
+        """
+        if self._legacy_container is None:
+            return None
+
+        prefix = table_name
+        query = "SELECT * FROM c WHERE STARTSWITH(c.id, @prefix)"
+        parameters: list[dict[str, Any]] = [
+            {"name": "@prefix", "value": f"{prefix}:"},
+        ]
+
+        docs: list[dict[str, Any]] = []
+        async for page in self._legacy_container.query_items(
+            query=query,
+            parameters=parameters,
+            enable_cross_partition_query=True,
+            max_item_count=_DEFAULT_PAGE_SIZE,
+        ).by_page():
+            async for doc in page:
+                # Strip the "{prefix}:" from the id.
+                raw_id = doc.get("id", "")
+                if ":" in raw_id:
+                    doc["id"] = raw_id.split(":", 1)[1]
+
+                # Reverse entity-specific hacks.
+                if table_name == "entities" and "entity_id" in doc:
+                    doc["id"] = doc.pop("entity_id")
+
+                docs.append(_strip_cosmos_metadata(doc))
+
+        if not docs:
+            return None
+        return pd.DataFrame(docs)
+
+    async def _legacy_table_exists(self, table_name: str) -> bool:
+        """Check if the legacy container has documents for this table prefix."""
+        if self._legacy_container is None:
+            return False
+        prefix = table_name
+        query = "SELECT VALUE COUNT(1) FROM c WHERE STARTSWITH(c.id, @prefix)"
+        parameters: list[dict[str, Any]] = [
+            {"name": "@prefix", "value": f"{prefix}:"},
+        ]
+        results: list[Any] = []
+        async for item in self._legacy_container.query_items(
+            query=query,
+            parameters=parameters,
+            enable_cross_partition_query=True,
+        ):
+            results.append(item)
+        return bool(results and results[0] > 0)
+
+
+class _LazyCosmosTable(Table):
+    """Wrapper that lazily resolves the container for CosmosTable.
+
+    open() is synchronous but _ensure_container() is async, so we defer
+    container resolution to the first async operation.
+    """
+
+    def __init__(
+        self,
+        provider: CosmosTableProvider,
+        table_name: str,
+        transformer: RowTransformer | None,
+        truncate: bool,
+    ) -> None:
+        self._provider = provider
+        self._table_name = table_name
+        self._transformer = transformer
+        self._truncate = truncate
+        self._inner: CosmosTable | None = None
+
+    async def _ensure_inner(self) -> CosmosTable:
+        if self._inner is None:
+            container = await self._provider._ensure_container()  # noqa: SLF001
+            self._inner = CosmosTable(
+                container=container,
+                table_name=self._table_name,
+                namespace=self._provider._namespace,  # noqa: SLF001
+                transformer=self._transformer,
+                truncate=self._truncate,
+            )
+        return self._inner
+
+    def __aiter__(self):
+        return self._aiter_impl()
+
+    async def _aiter_impl(self):
+        inner = await self._ensure_inner()
+        async for row in inner:
+            yield row
+
+    async def length(self) -> int:
+        inner = await self._ensure_inner()
+        return await inner.length()
+
+    async def has(self, row_id: str) -> bool:
+        inner = await self._ensure_inner()
+        return await inner.has(row_id)
+
+    async def write(self, row: dict[str, Any]) -> None:
+        inner = await self._ensure_inner()
+        await inner.write(row)
+
+    async def close(self) -> None:
+        if self._inner is not None:
+            await self._inner.close()

--- a/packages/graphrag-storage/graphrag_storage/tables/cosmos_table_provider.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/cosmos_table_provider.py
@@ -12,8 +12,8 @@ Partition key : /namespace
 Document id   : {table_name}:{row_key}
 
 Every document carries two internal fields used for routing:
-    namespace  – partition key, set by child() hierarchy
-    table_name – discriminator for per-table queries
+    namespace  - partition key, set by child() hierarchy
+    table_name - discriminator for per-table queries
 
 All queries target a single namespace partition (no cross-partition fan-out).
 """
@@ -43,24 +43,13 @@ _DEFAULT_PAGE_SIZE = 100
 _DEFAULT_BATCH_SIZE = 50
 _MAX_BATCH_SIZE = 100
 
-# Cosmos system / internal fields to exclude from DataFrame columns.
-_INTERNAL_FIELDS = frozenset({
-    "_rid",
-    "_self",
-    "_etag",
-    "_attachments",
-    "_ts",
-    "namespace",
-    "table_name",
-})
-
 
 class CosmosTableProvider(TableProvider):
     """TableProvider backed by Azure Cosmos DB (NoSQL API, async SDK).
 
     Each table is stored as a set of documents within a single container,
-    discriminated by the ``table_name`` field.  Namespace isolation (used
-    by the update pipeline's delta / previous split) is achieved via the
+    discriminated by the ``table_name`` field. Namespace isolation (used
+    by the update pipeline's delta/previous split) is achieved via the
     ``/namespace`` partition key.
     """
 
@@ -110,9 +99,7 @@ class CosmosTableProvider(TableProvider):
             raise ValueError(msg)
 
         if connection_string:
-            self._cosmos_client = CosmosClient.from_connection_string(
-                connection_string
-            )
+            self._cosmos_client = CosmosClient.from_connection_string(connection_string)
         else:
             self._cosmos_client = CosmosClient(
                 url=account_url,  # type: ignore[arg-type]
@@ -138,10 +125,8 @@ class CosmosTableProvider(TableProvider):
         if self._container is not None:
             return self._container
 
-        db: DatabaseProxy = (
-            await self._cosmos_client.create_database_if_not_exists(  # type: ignore[union-attr]
-                id=self._database_name
-            )
+        db: DatabaseProxy = await self._cosmos_client.create_database_if_not_exists(  # type: ignore[union-attr]
+            id=self._database_name
         )
         self._container = await db.create_container_if_not_exists(
             id=self._container_name,
@@ -177,7 +162,7 @@ class CosmosTableProvider(TableProvider):
             max_item_count=_DEFAULT_PAGE_SIZE,
         ).by_page():
             async for doc in page:
-                docs.append(_strip_cosmos_metadata(doc))
+                docs.append(_strip_cosmos_metadata(doc))  # noqa: PERF401
 
         if docs:
             return pd.DataFrame(docs)
@@ -225,9 +210,7 @@ class CosmosTableProvider(TableProvider):
     async def has(self, table_name: str) -> bool:
         """Check whether any documents exist for *table_name*."""
         container = await self._ensure_container()
-        query = (
-            "SELECT VALUE COUNT(1) FROM c WHERE c.table_name = @table_name"
-        )
+        query = "SELECT VALUE COUNT(1) FROM c WHERE c.table_name = @table_name"
         parameters: list[dict[str, Any]] = [
             {"name": "@table_name", "value": table_name},
         ]
@@ -237,7 +220,7 @@ class CosmosTableProvider(TableProvider):
             parameters=parameters,
             partition_key=self._namespace,
         ):
-            results.append(item)
+            results.append(item)  # noqa: PERF401
         if results and results[0] > 0:
             return True
 
@@ -277,7 +260,7 @@ class CosmosTableProvider(TableProvider):
             query=query,
             partition_key=self._namespace,
         ):
-            names.append(item)
+            names.append(item)  # noqa: PERF401
         return names
 
     def open(
@@ -299,7 +282,7 @@ class CosmosTableProvider(TableProvider):
     # child() — namespace isolation
     # ------------------------------------------------------------------
 
-    def child(self, name: str | None) -> "CosmosTableProvider":
+    def child(self, name: str | None) -> CosmosTableProvider:
         """Create a child provider with an extended namespace."""
         if name is None:
             return self
@@ -326,9 +309,7 @@ class CosmosTableProvider(TableProvider):
     # Internal helpers
     # ------------------------------------------------------------------
 
-    async def _delete_table(
-        self, container: ContainerProxy, table_name: str
-    ) -> None:
+    async def _delete_table(self, container: ContainerProxy, table_name: str) -> None:
         """Delete all documents for a table in the current namespace."""
         query = "SELECT c.id FROM c WHERE c.table_name = @table_name"
         parameters: list[dict[str, Any]] = [
@@ -399,7 +380,7 @@ class CosmosTableProvider(TableProvider):
             query=query,
             parameters=parameters,
         ):
-            results.append(item)
+            results.append(item)  # noqa: PERF401
         return bool(results and results[0] > 0)
 
 

--- a/packages/graphrag-storage/graphrag_storage/tables/cosmos_table_provider.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/cosmos_table_provider.py
@@ -40,6 +40,9 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_PAGE_SIZE = 100
 
+_DEFAULT_BATCH_SIZE = 50
+_MAX_BATCH_SIZE = 100
+
 # Cosmos system / internal fields to exclude from DataFrame columns.
 _INTERNAL_FIELDS = frozenset({
     "_rid",
@@ -74,12 +77,15 @@ class CosmosTableProvider(TableProvider):
         container_name: str | None = None,
         namespace: str = "",
         legacy_container: str | None = None,
+        batch_size: int = _DEFAULT_BATCH_SIZE,
         # Allow pre-built internals for child() and testing.
         _cosmos_client: CosmosClient | None = None,
         _container: ContainerProxy | None = None,
         _legacy_container: ContainerProxy | None = None,
         **kwargs: Any,
     ) -> None:
+        self._batch_size = min(max(batch_size, 1), _MAX_BATCH_SIZE)
+
         if _container is not None:
             # Fast path: child() or test injection.
             self._cosmos_client = _cosmos_client
@@ -200,6 +206,7 @@ class CosmosTableProvider(TableProvider):
         records = json.loads(
             df.to_json(orient="records", lines=False, force_ascii=False)
         )
+        docs = []
         for index, row in enumerate(records):
             row_key = row.pop("id", index)
             doc = {
@@ -211,7 +218,9 @@ class CosmosTableProvider(TableProvider):
             # Preserve the pipeline's id value so it round-trips.
             if "id" in df.columns:
                 doc["row_id"] = row_key
-            await container.upsert_item(body=doc)
+            docs.append(doc)
+
+        await _batch_upsert(container, docs, self._namespace, self._batch_size)
 
     async def has(self, table_name: str) -> bool:
         """Check whether any documents exist for *table_name*."""
@@ -278,13 +287,12 @@ class CosmosTableProvider(TableProvider):
         truncate: bool = True,
     ) -> Table:
         """Open a table for streaming row-by-row access."""
-        # _ensure_container() is async; CosmosTable will need the container.
-        # We use a lazy pattern: pass self so the table can call _ensure_container.
         return _LazyCosmosTable(
             provider=self,
             table_name=table_name,
             transformer=transformer,
             truncate=truncate,
+            batch_size=self._batch_size,
         )
 
     # ------------------------------------------------------------------
@@ -301,6 +309,7 @@ class CosmosTableProvider(TableProvider):
             _container=self._container,
             _legacy_container=self._legacy_container,
             namespace=child_ns,
+            batch_size=self._batch_size,
         )
 
     # ------------------------------------------------------------------
@@ -394,6 +403,37 @@ class CosmosTableProvider(TableProvider):
         return bool(results and results[0] > 0)
 
 
+async def _batch_upsert(
+    container: ContainerProxy,
+    docs: list[dict[str, Any]],
+    partition_key: str,
+    batch_size: int,
+) -> None:
+    """Upsert *docs* using transactional batches with single-upsert fallback.
+
+    Documents are split into chunks of *batch_size* (max 100). Each chunk is
+    sent as a transactional batch.  If a batch fails (e.g. payload too large),
+    the chunk is retried as individual upserts so that partial progress is
+    never lost.
+    """
+    from azure.cosmos.exceptions import CosmosBatchOperationError
+
+    for start in range(0, len(docs), batch_size):
+        chunk = docs[start : start + batch_size]
+        try:
+            ops = [("upsert", (doc,)) for doc in chunk]
+            await container.execute_item_batch(ops, partition_key=partition_key)
+        except (CosmosBatchOperationError, Exception):  # noqa: BLE001
+            logger.warning(
+                "Transactional batch failed for %d docs at offset %d; "
+                "falling back to individual upserts.",
+                len(chunk),
+                start,
+            )
+            for doc in chunk:
+                await container.upsert_item(body=doc)
+
+
 class _LazyCosmosTable(Table):
     """Wrapper that lazily resolves the container for CosmosTable.
 
@@ -407,11 +447,13 @@ class _LazyCosmosTable(Table):
         table_name: str,
         transformer: RowTransformer | None,
         truncate: bool,
+        batch_size: int = _DEFAULT_BATCH_SIZE,
     ) -> None:
         self._provider = provider
         self._table_name = table_name
         self._transformer = transformer
         self._truncate = truncate
+        self._batch_size = batch_size
         self._inner: CosmosTable | None = None
 
     async def _ensure_inner(self) -> CosmosTable:
@@ -423,6 +465,7 @@ class _LazyCosmosTable(Table):
                 namespace=self._provider._namespace,  # noqa: SLF001
                 transformer=self._transformer,
                 truncate=self._truncate,
+                batch_size=self._batch_size,
             )
         return self._inner
 

--- a/packages/graphrag-storage/graphrag_storage/tables/cosmos_table_provider.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/cosmos_table_provider.py
@@ -20,6 +20,7 @@ All queries target a single namespace partition (no cross-partition fan-out).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any
@@ -115,6 +116,7 @@ class CosmosTableProvider(TableProvider):
         self._legacy_container_name = legacy_container
         self._container: ContainerProxy | None = None  # type: ignore[assignment]
         self._legacy_container: ContainerProxy | None = None
+        self._container_lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
     # Lazy initialisation (async work we can't do in __init__)
@@ -125,19 +127,22 @@ class CosmosTableProvider(TableProvider):
         if self._container is not None:
             return self._container
 
-        db: DatabaseProxy = await self._cosmos_client.create_database_if_not_exists(  # type: ignore[union-attr]
-            id=self._database_name
-        )
-        self._container = await db.create_container_if_not_exists(
-            id=self._container_name,
-            partition_key=PartitionKey(path="/namespace", kind="Hash"),
-        )
+        async with self._container_lock:
+            if self._container is not None:
+                return self._container
 
-        if self._legacy_container_name:
-            # Legacy container already exists — just get a reference.
-            self._legacy_container = db.get_container_client(
-                self._legacy_container_name
+            db: DatabaseProxy = await self._cosmos_client.create_database_if_not_exists(  # type: ignore[union-attr]
+                id=self._database_name
             )
+            self._container = await db.create_container_if_not_exists(
+                id=self._container_name,
+                partition_key=PartitionKey(path="/namespace", kind="Hash"),
+            )
+
+            if self._legacy_container_name:
+                self._legacy_container = db.get_container_client(
+                    self._legacy_container_name
+                )
 
         return self._container
 
@@ -201,8 +206,7 @@ class CosmosTableProvider(TableProvider):
                 **row,
             }
             # Preserve the pipeline's id value so it round-trips.
-            if "id" in df.columns:
-                doc["row_id"] = row_key
+            doc["row_id"] = row_key
             docs.append(doc)
 
         await _batch_upsert(container, docs, self._namespace, self._batch_size)
@@ -404,7 +408,7 @@ async def _batch_upsert(
         try:
             ops = [("upsert", (doc,)) for doc in chunk]
             await container.execute_item_batch(ops, partition_key=partition_key)
-        except (CosmosBatchOperationError, Exception):  # noqa: BLE001
+        except CosmosBatchOperationError:
             logger.warning(
                 "Transactional batch failed for %d docs at offset %d; "
                 "falling back to individual upserts.",

--- a/packages/graphrag-storage/graphrag_storage/tables/cosmos_table_provider.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/cosmos_table_provider.py
@@ -4,7 +4,7 @@
 """Cosmos DB native table provider implementation.
 
 Stores each DataFrame row as a Cosmos document, eliminating the
-parquet serialisation round-trip used by ParquetTableProvider.
+parquet serialization round-trip used by ParquetTableProvider.
 
 Container schema
 ----------------
@@ -119,7 +119,7 @@ class CosmosTableProvider(TableProvider):
         self._container_lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
-    # Lazy initialisation (async work we can't do in __init__)
+    # Lazy initialization (async work we can't do in __init__)
     # ------------------------------------------------------------------
 
     async def _ensure_container(self) -> ContainerProxy:

--- a/packages/graphrag-storage/graphrag_storage/tables/cosmos_table_provider.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/cosmos_table_provider.py
@@ -358,7 +358,6 @@ class CosmosTableProvider(TableProvider):
         async for page in self._legacy_container.query_items(
             query=query,
             parameters=parameters,
-            enable_cross_partition_query=True,
             max_item_count=_DEFAULT_PAGE_SIZE,
         ).by_page():
             async for doc in page:
@@ -390,7 +389,6 @@ class CosmosTableProvider(TableProvider):
         async for item in self._legacy_container.query_items(
             query=query,
             parameters=parameters,
-            enable_cross_partition_query=True,
         ):
             results.append(item)
         return bool(results and results[0] > 0)

--- a/packages/graphrag-storage/graphrag_storage/tables/cosmos_table_provider.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/cosmos_table_provider.py
@@ -319,15 +319,17 @@ class CosmosTableProvider(TableProvider):
         parameters: list[dict[str, Any]] = [
             {"name": "@table_name", "value": table_name},
         ]
-        async for page in container.query_items(
-            query=query,
-            parameters=parameters,
-            partition_key=self._namespace,
-        ).by_page():
-            async for doc in page:
-                await container.delete_item(
-                    item=doc["id"], partition_key=self._namespace
-                )
+        ids: list[str] = [
+            doc["id"]
+            async for page in container.query_items(
+                query=query,
+                parameters=parameters,
+                partition_key=self._namespace,
+            ).by_page()
+            async for doc in page
+        ]
+        if ids:
+            await _batch_delete(container, ids, self._namespace, self._batch_size)
 
     # ------------------------------------------------------------------
     # Legacy fallback reads
@@ -417,6 +419,34 @@ async def _batch_upsert(
             )
             for doc in chunk:
                 await container.upsert_item(body=doc)
+
+
+async def _batch_delete(
+    container: ContainerProxy,
+    item_ids: list[str],
+    partition_key: str,
+    batch_size: int,
+) -> None:
+    """Delete items by ID using transactional batches with single-delete fallback.
+
+    Same chunking and fallback strategy as :func:`_batch_upsert`.
+    """
+    from azure.cosmos.exceptions import CosmosBatchOperationError
+
+    for start in range(0, len(item_ids), batch_size):
+        chunk = item_ids[start : start + batch_size]
+        try:
+            ops = [("delete", (item_id,)) for item_id in chunk]
+            await container.execute_item_batch(ops, partition_key=partition_key)
+        except CosmosBatchOperationError:
+            logger.warning(
+                "Transactional batch delete failed for %d items at offset %d; "
+                "falling back to individual deletes.",
+                len(chunk),
+                start,
+            )
+            for item_id in chunk:
+                await container.delete_item(item=item_id, partition_key=partition_key)
 
 
 class _LazyCosmosTable(Table):

--- a/packages/graphrag-storage/graphrag_storage/tables/csv_table_provider.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/csv_table_provider.py
@@ -138,3 +138,13 @@ class CSVTableProvider(TableProvider):
             truncate=truncate,
             encoding=encoding,
         )
+
+    def child(self, name: str | None) -> "CSVTableProvider":
+        """Create a child provider backed by a child storage namespace."""
+        if name is None:
+            return self
+        child_storage = self._storage.child(name)
+        if not isinstance(child_storage, FileStorage):
+            msg = "CSVTableProvider only works with FileStorage backends for now."
+            raise TypeError(msg)
+        return CSVTableProvider(storage=child_storage)

--- a/packages/graphrag-storage/graphrag_storage/tables/parquet_table_provider.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/parquet_table_provider.py
@@ -136,3 +136,9 @@ class ParquetTableProvider(TableProvider):
                 A ParquetTable instance for row-by-row access.
         """
         return ParquetTable(self._storage, table_name, transformer, truncate=truncate)
+
+    def child(self, name: str | None) -> "ParquetTableProvider":
+        """Create a child provider backed by a child storage namespace."""
+        if name is None:
+            return self
+        return ParquetTableProvider(storage=self._storage.child(name))

--- a/packages/graphrag-storage/graphrag_storage/tables/table_provider.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/table_provider.py
@@ -100,3 +100,22 @@ class TableProvider(ABC):
             Table:
                 A Table instance for streaming row operations.
         """
+
+    def child(self, name: str | None) -> "TableProvider":
+        """Create a namespaced child provider.
+
+        Used by the update pipeline to isolate delta/previous table sets.
+        Default implementation returns self (no namespacing).
+        Subclasses should override to provide proper isolation.
+
+        Args
+        ----
+            name: str | None
+                The namespace name for the child provider.
+
+        Returns
+        -------
+            TableProvider:
+                A child table provider instance.
+        """
+        return self

--- a/packages/graphrag-storage/graphrag_storage/tables/table_provider_config.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/table_provider_config.py
@@ -19,21 +19,6 @@ class TableProviderConfig(BaseModel):
         default=TableType.Parquet,
     )
 
-    connection_string: str | None = Field(
-        description="The connection string for Cosmos DB.",
-        default=None,
-    )
-
-    account_url: str | None = Field(
-        description="The account URL for Cosmos DB (used with managed identity).",
-        default=None,
-    )
-
-    database_name: str | None = Field(
-        description="The Cosmos DB database name.",
-        default=None,
-    )
-
     container_name: str | None = Field(
         description="The Cosmos DB container name for table storage.",
         default=None,

--- a/packages/graphrag-storage/graphrag_storage/tables/table_provider_config.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/table_provider_config.py
@@ -43,3 +43,8 @@ class TableProviderConfig(BaseModel):
         description="Optional legacy Cosmos DB container name for read-time migration fallback.",
         default=None,
     )
+
+    batch_size: int = Field(
+        description="Number of documents per transactional batch write for Cosmos DB. Max 100.",
+        default=50,
+    )

--- a/packages/graphrag-storage/graphrag_storage/tables/table_provider_config.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/table_provider_config.py
@@ -15,6 +15,31 @@ class TableProviderConfig(BaseModel):
     """Allow extra fields to support custom table provider implementations."""
 
     type: str = Field(
-        description="The table type to use.",
+        description="The table type to use. Builtin types include 'parquet', 'csv', and 'cosmosdb'.",
         default=TableType.Parquet,
+    )
+
+    connection_string: str | None = Field(
+        description="The connection string for Cosmos DB.",
+        default=None,
+    )
+
+    account_url: str | None = Field(
+        description="The account URL for Cosmos DB (used with managed identity).",
+        default=None,
+    )
+
+    database_name: str | None = Field(
+        description="The Cosmos DB database name.",
+        default=None,
+    )
+
+    container_name: str | None = Field(
+        description="The Cosmos DB container name for table storage.",
+        default=None,
+    )
+
+    legacy_container: str | None = Field(
+        description="Optional legacy Cosmos DB container name for read-time migration fallback.",
+        default=None,
     )

--- a/packages/graphrag-storage/graphrag_storage/tables/table_provider_factory.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/table_provider_factory.py
@@ -85,4 +85,25 @@ def create_table_provider(
     if storage:
         config_model["storage"] = storage
 
+    # For CosmosDB table providers, extract connection details from the
+    # affiliated Storage instance so users only configure credentials once
+    # (on output_storage).  Table-specific fields (container_name,
+    # batch_size, legacy_container) stay on TableProviderConfig.
+    if table_type == TableType.CosmosDB and storage is not None:
+        from graphrag_storage.azure_cosmos_storage import AzureCosmosStorage
+
+        if isinstance(storage, AzureCosmosStorage):
+            config_model.setdefault(
+                "connection_string",
+                storage._connection_string,  # noqa: SLF001
+            )
+            config_model.setdefault(
+                "account_url",
+                storage._cosmosdb_account_url,  # noqa: SLF001
+            )
+            config_model.setdefault(
+                "database_name",
+                storage._database_name,  # noqa: SLF001
+            )
+
     return table_provider_factory.create(table_type, config_model)

--- a/packages/graphrag-storage/graphrag_storage/tables/table_provider_factory.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/table_provider_factory.py
@@ -72,6 +72,12 @@ def create_table_provider(
                 )
 
                 register_table_provider(TableType.CSV, CSVTableProvider)
+            case TableType.CosmosDB:
+                from graphrag_storage.tables.cosmos_table_provider import (
+                    CosmosTableProvider,
+                )
+
+                register_table_provider(TableType.CosmosDB, CosmosTableProvider)
             case _:
                 msg = f"TableProviderConfig.type '{table_type}' is not registered in the TableProviderFactory. Registered types: {', '.join(table_provider_factory.keys())}."
                 raise ValueError(msg)

--- a/packages/graphrag-storage/graphrag_storage/tables/table_type.py
+++ b/packages/graphrag-storage/graphrag_storage/tables/table_type.py
@@ -12,3 +12,4 @@ class TableType(StrEnum):
 
     Parquet = "parquet"
     CSV = "csv"
+    CosmosDB = "cosmosdb"

--- a/packages/graphrag/graphrag/index/run/run_pipeline.py
+++ b/packages/graphrag/graphrag/index/run/run_pipeline.py
@@ -59,15 +59,16 @@ async def run_pipeline(
         update_timestamp = time.strftime("%Y%m%d-%H%M%S")
         timestamped_storage = update_storage.child(update_timestamp)
         delta_storage = timestamped_storage.child("delta")
-        delta_table_provider = create_table_provider(
-            config.table_provider, delta_storage
+        # Build table providers via child() so Cosmos providers use namespace
+        # isolation while file/blob providers delegate to Storage.child().
+        update_base_provider = create_table_provider(
+            config.table_provider, update_storage
         )
+        update_table_provider = update_base_provider.child(update_timestamp)
+        delta_table_provider = update_table_provider.child("delta")
         # copy the previous output to a backup folder, so we can replace it with the update
         # we'll read from this later when we merge the old and new indexes
-        previous_storage = timestamped_storage.child("previous")
-        previous_table_provider = create_table_provider(
-            config.table_provider, previous_storage
-        )
+        previous_table_provider = update_table_provider.child("previous")
 
         await _copy_previous_output(output_table_provider, previous_table_provider)
 

--- a/packages/graphrag/graphrag/index/run/utils.py
+++ b/packages/graphrag/graphrag/index/run/utils.py
@@ -61,15 +61,15 @@ def get_update_table_providers(
 ) -> tuple[TableProvider, TableProvider, TableProvider]:
     """Get table providers for the update index run."""
     output_storage = create_storage(config.output_storage)
-    update_storage = create_storage(config.update_output_storage)
-    timestamped_storage = update_storage.child(timestamp)
-    delta_storage = timestamped_storage.child("delta")
-    previous_storage = timestamped_storage.child("previous")
-
     output_table_provider = create_table_provider(config.table_provider, output_storage)
-    previous_table_provider = create_table_provider(
-        config.table_provider, previous_storage
-    )
-    delta_table_provider = create_table_provider(config.table_provider, delta_storage)
+
+    # Build update providers via table_provider.child() so that Cosmos
+    # providers use namespace isolation while file/blob providers delegate
+    # to Storage.child() for filesystem paths.
+    update_storage = create_storage(config.update_output_storage)
+    update_base_provider = create_table_provider(config.table_provider, update_storage)
+    timestamped_provider = update_base_provider.child(timestamp)
+    delta_table_provider = timestamped_provider.child("delta")
+    previous_table_provider = timestamped_provider.child("previous")
 
     return output_table_provider, previous_table_provider, delta_table_provider

--- a/tests/integration/storage/test_cosmosdb_storage.py
+++ b/tests/integration/storage/test_cosmosdb_storage.py
@@ -100,8 +100,8 @@ async def test_clear():
         output = await storage.get("easter.json")
         assert output is None
 
-        assert storage._container_client is None  # noqa: SLF001
-        assert storage._database_client is None  # noqa: SLF001
+        assert storage._container_client is not None  # noqa: SLF001
+        assert storage._database_client is not None  # noqa: SLF001
     finally:
         await storage.clear()
 


### PR DESCRIPTION
## Summary

Replaces the parquet-decomposition approach in `AzureCosmosStorage` with a native `CosmosTableProvider` that implements `TableProvider` directly against Cosmos DB.

## Problem

The current Cosmos DB integration forces all data through a parquet serialization layer designed for file/blob storage, causing:

- **4 serde hops** per read/write (DataFrame → parquet → DataFrame → JSON → Cosmos, reversed on read)
- **Cross-partition fan-out** on every multi-row query (partition key is `/id`, so each document is its own partition)
- **Entity-specific hacks** in the storage layer (`if prefix == "entities":`)
- **Broken `child()`** — no-op, so update-run delta/previous isolation doesn't work
- **`clear()` drops the entire database**
- **Sync SDK** used inside async methods (blocks event loop)
- **Unparameterized f-string queries**

## Solution

| | Before | After |
|---|---|---|
| Serde hops | 4 per read/write | 1 |
| Query pattern | Cross-partition fan-out | Single-partition |
| Entity hacks in storage | Yes | None |
| Update-run isolation | Broken | Namespace partitioning |
| SDK | Sync (blocks event loop) | Async |
| Query safety | f-string interpolation | Parameterized |
| Write strategy | Row-by-row upsert | Transactional batch (default 50, max 100) |

### Architecture

- **`CosmosTableProvider`** implements `TableProvider` directly — DataFrame rows become Cosmos documents natively. Partition key is `/namespace`, co-locating all data for a logical scope in a single partition.
- **`CosmosTable`** implements `Table` for streaming row access with async SDK and server-side pagination.
- **`AzureCosmosStorage`** simplified to key-value only (context.json, stats.json, cache). Working `child()` via `:` namespace prefix.
- **`TableProvider.child()`** — new non-abstract method for namespace isolation. `ParquetTableProvider`/`CSVTableProvider` delegate to `Storage.child()`.
- **Transactional batch writes** — configurable `batch_size` (default 50, max 100) with automatic fallback to individual upserts on batch failure.

### Migration

- **Legacy fallback reads**: when `legacy_container` is configured, reads transparently from old-format containers while writing exclusively to the new schema.
- **Re-index migrates data** automatically (reads from legacy, writes to new).
- **CLI tool** (`graphrag migrate-cosmos`) planned for migration without re-indexing.

## Changes

| File | Change |
|------|--------|
| `graphrag_storage/tables/table_provider.py` | Add `child()` default method |
| `graphrag_storage/tables/table_type.py` | Add `CosmosDB` enum |
| `graphrag_storage/tables/table_provider_config.py` | Add Cosmos + batch_size fields |
| `graphrag_storage/tables/cosmos_table_provider.py` | **New** — native Cosmos table provider |
| `graphrag_storage/tables/cosmos_table.py` | **New** — streaming Table impl |
| `graphrag_storage/tables/table_provider_factory.py` | Wire `cosmosdb` case |
| `graphrag_storage/tables/parquet_table_provider.py` | Add `child()` |
| `graphrag_storage/tables/csv_table_provider.py` | Add `child()` |
| `graphrag_storage/azure_cosmos_storage.py` | Simplified to key-value only |
| `graphrag/index/run/run_pipeline.py` | Use `table_provider.child()` |
| `graphrag/index/run/utils.py` | Refactor `get_update_table_providers` |

## Testing

- 302 unit tests + 15 verb tests pass (no regressions)
- pyright: 0 errors, ruff: all checks pass
- E2E tested against Cosmos DB Linux emulator (vNext, ARM64):
  - CosmosTableProvider lifecycle (write, read, has, list, child, open, stream, truncate, batch)
  - AzureCosmosStorage key-value (set, get, has, child, keys, delete, clear)
  - Factory wiring, update-run simulation, full migration scenario

## Config

```yaml
table_provider:
  type: cosmosdb
  account_url: https://myaccount.documents.azure.com:443/
  database_name: graphrag
  container_name: graphrag-tables
  batch_size: 50              # default; max 100
  legacy_container: graphrag-output  # optional: enables migration fallback
```

<img width="1009" height="759" alt="image" src="https://github.com/user-attachments/assets/12035dfc-a25d-46e8-92f6-a5537abf7e3d" />

