### PR TITLE
fix: preserve entities without community assignments in level filter (fixes #2348)

### DIFF
--- a/packages/graphrag/graphrag/query/indexer_adapters.py
+++ b/packages/graphrag/graphrag/query/indexer_adapters.py
@@ -221,5 +221,5 @@ def _filter_under_community_level(
 ) -> pd.DataFrame:
     return cast(
         "pd.DataFrame",
-        df[df.level <= community_level],
+        df[(df.level <= community_level) | df.level.isna()],
     )


### PR DESCRIPTION
﻿## Summary

\_filter_under_community_level\ uses \df[df.level <= community_level]\ which evaluates to \False\ for NaN values. Entities not assigned to any community by Leiden detection get \level = NaN\ after a left join and are silently dropped, causing the query engine to operate on a drastically reduced entity set with no warning.

## Changes

\graphrag/query/indexer_adapters.py\: Added \| df.level.isna()\ to the filter condition so that entities without community assignments are preserved. Since "not in any community" is not the same as "in a community above the requested level," retaining them is the semantically correct behavior.

## Related

Fixes #2348
