### PR TITLE
fix(config): use safe_substitute to prevent crashes on $ in config values (fixes #2349)

### DIFF
--- a/packages/graphrag-common/graphrag_common/config/load_config.py
+++ b/packages/graphrag-common/graphrag_common/config/load_config.py
@@ -84,11 +84,7 @@ def _get_parser_for_file(file_path: str | Path) -> Callable[[str], dict[str, Any
 
 def _parse_env_variables(text: str) -> str:
     """Parse environment variables in the configuration text."""
-    try:
-        return Template(text).substitute(os.environ)
-    except KeyError as error:
-        msg = f"Environment variable not found: {error}"
-        raise ConfigParsingError(msg) from error
+    return Template(text).safe_substitute(os.environ)
 
 
 def _recursive_merge_dicts(dest: dict[str, Any], src: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

Replace `substitute()` with `safe_substitute()` in config env-var parsing so that bare `$` characters (e.g. regex `file_pattern: ".*\\.txt$"`) don't crash the config loader.

## Changes

- In `graphrag-common/graphrag_common/config/load_config.py`, replaced `Template(text).substitute(os.environ)` with `Template(text).safe_substitute(os.environ)`
- Removed the now-unnecessary `try/except KeyError` wrapper, since `safe_substitute()` never raises `KeyError` or `ValueError`

## Issue

Fixes #2349

## Verification

```python
>>> from string import Template
>>> t = Template('.*\\.txt$')
>>> t.safe_substitute({})
'.*\\.txt$'
```

`safe_substitute()` leaves unrecognized `$` patterns as literal text instead of raising `ValueError`.
