### PR TITLE
fix: preserve entities without community assignment in _filter_under_community_level (#2348)

### DIFF
--- a/packages/graphrag/graphrag/query/indexer_adapters.py
+++ b/packages/graphrag/graphrag/query/indexer_adapters.py
@@ -217,9 +217,11 @@ def embed_community_reports(
 
 
 def _filter_under_community_level(
-    df: pd.DataFrame, community_level: int
+    df: pd.DataFrame, community_level: int | None
 ) -> pd.DataFrame:
+    if community_level is None:
+        return df
     return cast(
         "pd.DataFrame",
-        df[df.level <= community_level],
+        df[(df.level <= community_level) | df.level.isna()],
     )


### PR DESCRIPTION
## Summary

Fix #2348: `_filter_under_community_level()` uses `df.level <= community_level` which evaluates to `False` for NaN values, silently dropping all entities that were not assigned to any community during Leiden community detection. This causes CLI query commands to operate on a drastically reduced entity set with no warning.

## Changes

In `graphrag/query/indexer_adapters.py`:
- Added `| df.level.isna()` to the filter condition so entities without community assignment are preserved
- Added `None` handling for `community_level` parameter so callers can bypass the filter

## Issue

Fixes #2348
