### PR TITLE
fix: add missing return type hints on generator functions in text_utils.py (fixes #2330)

### DIFF
--- a/packages/graphrag/graphrag/query/llm/text_utils.py
+++ b/packages/graphrag/graphrag/query/llm/text_utils.py
@@ -17,7 +17,7 @@ from graphrag.tokenizer.get_tokenizer import get_tokenizer
 logger = logging.getLogger(__name__)
 
 
-def batched(iterable: Iterator, n: int):
+def batched(iterable: Iterator, n: int) -> Iterator[tuple]:
     """
     Batch data into tuples of length n. The last batch may be shorter.
 
@@ -32,7 +32,7 @@ def batched(iterable: Iterator, n: int):
         yield batch
 
 
-def chunk_text(text: str, max_tokens: int, tokenizer: Tokenizer | None = None):
+def chunk_text(text: str, max_tokens: int, tokenizer: Tokenizer | None = None) -> Iterator[str]:
     """Chunk text by token length."""
     if tokenizer is None:
         tokenizer = get_tokenizer()


### PR DESCRIPTION
## Summary

Add missing return type hints to two generator functions in \	ext_utils.py\.

## Changes

- \atched(iterable, n)\: \-> Iterator[tuple]\
- \chunk_text(text, max_tokens, tokenizer)\: \-> Iterator[str]\

## Issue

Fixes #2330

## Verification

- Annotation-only change, zero runtime impact
- \collections.abc.Iterator\ already imported