### PR TITLE
fix: preserve NaN-level entities in _filter_under_community_level (fixes #2348)

### DIFF
--- a/packages/graphrag/graphrag/query/indexer_adapters.py
+++ b/packages/graphrag/graphrag/query/indexer_adapters.py
@@ -221,5 +221,5 @@ def _filter_under_community_level(
 ) -> pd.DataFrame:
     return cast(
         "pd.DataFrame",
-        df[df.level <= community_level],
+        df[(df.level <= community_level) | df.level.isna()],
     )


### PR DESCRIPTION
## Summary

`_filter_under_community_level()` filters rows with `df[df.level <= community_level]`. In pandas/NumPy, `np.nan <= X` evaluates to `False`, so entities without community assignments (where `level` is `NaN` after a left join) are silently dropped from query results.

This fix adds `| df.level.isna()` to the filter condition, preserving entities that have no community assignment. "Not assigned to any community" is semantically different from "assigned to a community above the requested level."

## Issue

Fixes #2348

## Verification

- Verified with isolated test: NaN entities now preserved, normal filtering unchanged
- 4 test scenarios pass: NaN preservation, normal filtering, community_level=0 edge case
