### PR TITLE
fix: use safe_substitute to prevent crash on dollar signs in config values (fixes #2349)

### DIFF
--- a/packages/graphrag-common/graphrag_common/config/load_config.py
+++ b/packages/graphrag-common/graphrag_common/config/load_config.py
@@ -84,11 +84,7 @@ def _get_parser_for_file(file_path: str | Path) -> Callable[[str], dict[str, Any
 
 def _parse_env_variables(text: str) -> str:
     """Parse environment variables in the configuration text."""
-    try:
-        return Template(text).substitute(os.environ)
-    except KeyError as error:
-        msg = f"Environment variable not found: {error}"
-        raise ConfigParsingError(msg) from error
+    return Template(text).safe_substitute(os.environ)
 
 
 def _recursive_merge_dicts(dest: dict[str, Any], src: dict[str, Any]) -> None:


### PR DESCRIPTION
The config loader uses string.Template.substitute() to process environment variables in settings.yaml. However, substitute() treats every dollar sign character as a placeholder prefix, causing a hard crash with ValueError when dollar signs appear in regex patterns like file_pattern.

Replaced substitute() with safe_substitute(), which silently leaves unrecognized placeholders as literal text instead of raising an error. Environment variable substitution still works correctly.

Fixes #2349
