### PR TITLE
fix: use safe_substitute in config loader to avoid crash on $ in values (fixes #2349)

### DIFF
--- a/packages/graphrag-common/graphrag_common/config/load_config.py
+++ b/packages/graphrag-common/graphrag_common/config/load_config.py
@@ -84,11 +84,7 @@ def _get_parser_for_file(file_path: str | Path) -> Callable[[str], dict[str, Any
 
 def _parse_env_variables(text: str) -> str:
     """Parse environment variables in the configuration text."""
-    try:
-        return Template(text).substitute(os.environ)
-    except KeyError as error:
-        msg = f"Environment variable not found: {error}"
-        raise ConfigParsingError(msg) from error
+    return Template(text).safe_substitute(os.environ)
 
 
 def _recursive_merge_dicts(dest: dict[str, Any], src: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

Replaces string.Template.substitute() with safe_substitute() in the config loader so that bare \$ characters (e.g. in regex file_pattern values) don't crash the entire pipeline.

## Issue

Closes #2349

## Root Cause

Template.substitute() raises ValueError on any \$ not followed by a valid placeholder identifier. Config values like file_pattern: '.*\\\\.md\$' trigger this.

## Fix

Replace substitute() with safe_substitute(), which leaves unrecognized placeholders as literal text.

## Verification

- Dollar sign in regex anchor: preserved as-is
- \ substitution: still works
- Missing env var \: left as literal text, no crash