### PR TITLE
fix: DynamicCommunitySelection crashes with KeyError when no communities at level 0

### DIFF
--- a/packages/graphrag/graphrag/query/context_builder/dynamic_community_selection.py
+++ b/packages/graphrag/graphrag/query/context_builder/dynamic_community_selection.py
@@ -68,7 +68,7 @@ class DynamicCommunitySelection:
                 self.levels[community.level].append(community.short_id)
 
         # start from root communities (level 0)
-        self.starting_communities = self.levels["0"]
+        self.starting_communities = self.levels.get("0", [])
 
     async def select(self, query: str) -> tuple[list[CommunityReport], dict[str, Any]]:
         """

--- a/tests/unit/query/context_builder/dynamic_community_selection.py
+++ b/tests/unit/query/context_builder/dynamic_community_selection.py
@@ -203,3 +203,62 @@ def test_dynamic_community_selection_handles_str_children():
         assert child_id in selector.reports, (
             f"Child {child} (as '{child_id}') should be found in reports"
         )
+
+
+def test_dynamic_community_selection_no_level_zero():
+    """DynamicCommunitySelection should not crash when no communities exist at level 0."""
+    communities = [
+        Community(
+            id="comm-1",
+            short_id="1",
+            title="Community at Level 1",
+            level="1",
+            parent="",
+            children=[],
+        ),
+        Community(
+            id="comm-2",
+            short_id="2",
+            title="Community at Level 2",
+            level="2",
+            parent="",
+            children=[],
+        ),
+    ]
+
+    reports = [
+        CommunityReport(
+            id="report-1",
+            short_id="1",
+            title="Report 1",
+            community_id="1",
+            summary="Summary 1",
+            full_content="Full content 1",
+            rank=1.0,
+        ),
+        CommunityReport(
+            id="report-2",
+            short_id="2",
+            title="Report 2",
+            community_id="2",
+            summary="Summary 2",
+            full_content="Full content 2",
+            rank=1.0,
+        ),
+    ]
+
+    model = create_mock_model()
+    tokenizer = create_mock_tokenizer()
+
+    selector = DynamicCommunitySelection(
+        community_reports=reports,
+        communities=communities,
+        model=model,
+        tokenizer=tokenizer,
+        threshold=1,
+        keep_parent=False,
+        max_level=2,
+    )
+
+    assert selector.starting_communities == []
+    assert "0" not in selector.levels


### PR DESCRIPTION
Fixes #2382

## Problem

`DynamicCommunitySelection.__init__` at `dynamic_community_selection.py:71` accesses `self.levels["0"]` directly. When the input data contains no communities at level "0" (e.g., all communities start at level "1" or the list is empty), this raises `KeyError: '0'` and crashes the dynamic community selection flow.

`self.levels` is built from the communities list — if no community has `level="0"`, the key is never added.

## Fix

Replace `self.levels["0"]` with `self.levels.get("0", [])` so that `starting_communities` defaults to an empty list when no root-level communities exist.

## Test

Added `test_dynamic_community_selection_no_level_zero` which creates communities only at levels 1 and 2 (no level 0) and verifies:
- The constructor does not raise `KeyError`
- `selector.starting_communities` is an empty list
- `"0"` is absent from `selector.levels`
