### PR TITLE
fix: remove extraneous True argument from dry-run logger.info call

### DIFF
--- a/packages/graphrag/graphrag/cli/index.py
+++ b/packages/graphrag/graphrag/cli/index.py
@@ -116,7 +116,7 @@ def _run_index(
     )
 
     if dry_run:
-        logger.info("Dry run complete, exiting...", True)
+        logger.info("Dry run complete, exiting...")
         sys.exit(0)
 
     _register_signal_handlers()


### PR DESCRIPTION
## Description

When running `graphrag index --dry-run --verbose`, the `logger.info()` call on line 119 of `graphrag/cli/index.py` passes an extraneous positional argument `True`:

```python
logger.info("Dry run complete, exiting...", True)
```

The message string has no `%s` placeholder, so Python's `logging` module raises:
`TypeError: not all arguments converted during string formatting`

This was the actual error reported in the issue, masked behind the logging error handler.

## Fix

Removed the stray `True` argument so the call is:
```python
logger.info("Dry run complete, exiting...")
```

## Related Issues

Fixes #2254

## Verification

- `pytest tests/unit/config/ -v` — 10/10 passed
- `pytest tests/unit/chunking/ -v` — 11/11 passed
