### PR TITLE
fix(graphrag-llm): accept non-OpenAI service_tier values in LLMCompletionResponse

### DIFF
--- a/.semversioner/next-release/patch-2026053119245844167500.json
+++ b/.semversioner/next-release/patch-2026053119245844167500.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Allow non-OpenAI service_tier values in LLMCompletionResponse so indexing does not fail with LiteLLM-routed providers (e.g. Gemini via OpenRouter)."
+}

--- a/packages/graphrag-llm/graphrag_llm/types/types.py
+++ b/packages/graphrag-llm/graphrag_llm/types/types.py
@@ -91,6 +91,12 @@ class LLMCompletionResponse(ChatCompletion, Generic[ResponseFormat]):
     provided ResponseFormat model.
     """
 
+    # Widen OpenAI's strict `service_tier` literal. Non-OpenAI providers routed
+    # through LiteLLM (e.g. Gemini via OpenRouter) return values outside OpenAI's
+    # enum, which would otherwise fail pydantic validation when constructing this
+    # model. graphrag-llm does not use this field. See issue #2389.
+    service_tier: str | None = None  # type: ignore
+
     formatted_response: ResponseFormat | None = None  # type: ignore
     """Formatted response according to the specified response_format json schema."""
 


### PR DESCRIPTION
Closes #2389

## Problem

Non-OpenAI providers routed through LiteLLM (e.g. Gemini via OpenRouter) return a `service_tier` value outside OpenAI's strict literal (`auto`/`default`/`flex`/`scale`/`priority`). Because `LLMCompletionResponse` extends `openai.types.chat.ChatCompletion`, constructing it via `LLMCompletionResponse(**response.model_dump())` in `lite_llm_completion.py` fails with a pydantic `literal_error`, breaking the `extract_graph` workflow:

```
1 validation error for LLMCompletionResponse
service_tier
  Input should be 'auto', 'default', 'flex', 'scale' or 'priority'
```

## Fix

`service_tier` is an OpenAI-specific field that graphrag-llm does not use. This overrides it in the `LLMCompletionResponse` subclass to accept `str | None`, so non-standard provider values no longer fail validation. This is more robust than stripping the field on a single conversion path, as it covers every place the model is constructed.

## Verification

- Constructing `LLMCompletionResponse` with a non-OpenAI `service_tier` (e.g. an OpenRouter value) now succeeds instead of raising.
- Standard OpenAI values (`default`) and `None` still work.
- The `content` computed field is unaffected.
- `ruff check` / `ruff format --check` pass; semversioner change file added.