### PR TITLE
Fix whitespace-only LanceDB db_uri fallback

### DIFF
--- a/.semversioner/next-release/patch-20260601101913537242.json
+++ b/.semversioner/next-release/patch-20260601101913537242.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Fix whitespace-only LanceDB vector store db_uri fallback."
+}

--- a/packages/graphrag/graphrag/config/models/graph_rag_config.py
+++ b/packages/graphrag/graphrag/config/models/graph_rag_config.py
@@ -270,7 +270,8 @@ class GraphRagConfig(BaseModel):
         """Validate the vector store configuration."""
         store = self.vector_store
         if store.type == VectorStoreType.LanceDB:
-            if not store.db_uri or store.db_uri.strip == "":
+            # Treat whitespace-only values the same as a missing db_uri.
+            if not store.db_uri or store.db_uri.strip() == "":
                 store.db_uri = graphrag_config_defaults.vector_store.db_uri
             store.db_uri = str(Path(store.db_uri).resolve())
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 from unittest import mock
 
+from graphrag.config.defaults import graphrag_config_defaults
 from graphrag.config.load_config import load_config
 from graphrag.config.models.graph_rag_config import GraphRagConfig
 
@@ -24,6 +25,18 @@ def test_default_config() -> None:
         embedding_models=DEFAULT_EMBEDDING_MODELS,  # type: ignore
     )
     assert_graphrag_configs(actual, expected)
+
+
+def test_lancedb_vector_store_whitespace_db_uri_uses_default() -> None:
+    actual = GraphRagConfig(
+        completion_models=DEFAULT_COMPLETION_MODELS,  # type: ignore
+        embedding_models=DEFAULT_EMBEDDING_MODELS,  # type: ignore
+        vector_store={"db_uri": "   "},
+    )
+
+    # Whitespace-only values are equivalent to an omitted db_uri.
+    expected_db_uri = Path(graphrag_config_defaults.vector_store.db_uri).resolve()
+    assert actual.vector_store.db_uri == str(expected_db_uri)
 
 
 @mock.patch.dict(os.environ, {"CUSTOM_API_KEY": FAKE_API_KEY}, clear=True)


### PR DESCRIPTION
## Description

Fixes LanceDB vector store db_uri validation so whitespace-only values fall back to the default db_uri instead of resolving to the current working directory.

## Related Issues

Fixes #2381

## Proposed Changes

- Call `strip()` when checking whether the LanceDB db_uri is blank.
- Add a unit test covering whitespace-only db_uri values.
- Add a semversioner patch change entry.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes

Validation run locally:

- `uv run pytest tests/unit/config/test_config.py -q`
- `uv run ruff format packages/graphrag/graphrag/config/models/graph_rag_config.py tests/unit/config/test_config.py --check`
- `uv run ruff check packages/graphrag/graphrag/config/models/graph_rag_config.py tests/unit/config/test_config.py`