### PR TITLE
fix: validate LanceDB vector dimensions before batch writes

### DIFF
--- a/packages/graphrag-vectors/graphrag_vectors/lancedb.py
+++ b/packages/graphrag-vectors/graphrag_vectors/lancedb.py
@@ -91,6 +91,15 @@ class LanceDBVectorStore(VectorStore):
             if document.vector is None:
                 continue
 
+            actual_vector_size = len(document.vector)
+            if actual_vector_size != self.vector_size:
+                msg = (
+                    f"Vector for document '{document.id}' has dimension "
+                    f"{actual_vector_size}, but index '{self.index_name}' is "
+                    f"configured with vector_size {self.vector_size}."
+                )
+                raise ValueError(msg)
+
             ids.append(str(document.id))
             vectors.append(np.array(document.vector, dtype=np.float32))
             create_dates.append(document.create_date)

--- a/tests/integration/vector_stores/test_lancedb.py
+++ b/tests/integration/vector_stores/test_lancedb.py
@@ -163,6 +163,32 @@ class TestLanceDBVectorStore:
         store.load_documents(sample_documents_with_metadata)
         assert store.count() == 3
 
+    def test_load_documents_rejects_mismatched_vector_size(self):
+        """Test loading a batch with a wrong-sized vector raises a clear error."""
+        temp_dir = tempfile.mkdtemp()
+        try:
+            vector_store = LanceDBVectorStore(
+                db_uri=temp_dir, index_name="dim_mismatch", vector_size=5
+            )
+            vector_store.connect()
+            vector_store.create_index()
+
+            documents = [
+                VectorStoreDocument(id="good", vector=[0.1, 0.2, 0.3, 0.4, 0.5]),
+                VectorStoreDocument(id="bad", vector=[0.1, 0.2, 0.3]),
+            ]
+
+            with pytest.raises(
+                ValueError,
+                match=(
+                    "Vector for document 'bad' has dimension 3, "
+                    "but index 'dim_mismatch' is configured with vector_size 5"
+                ),
+            ):
+                vector_store.load_documents(documents)
+        finally:
+            shutil.rmtree(temp_dir)
+
     def test_search_by_id(self, store_with_fields, sample_documents_with_metadata):
         """Test searching for a document by id returns all fields."""
         store = store_with_fields


### PR DESCRIPTION
## Summary

Fixes #2265 by validating each LanceDB document vector against the configured `vector_size` before constructing the PyArrow fixed-size-list column.

When the embedding model returns vectors with a different dimension than the configured LanceDB index, the current code reaches `FixedSizeListArray.from_arrays(...)` and fails later with a confusing row-count-style Arrow error such as `Column 1 named vector expected length 44 but got length 11`. This change fails earlier with the exact document id, actual vector dimension, index name, and configured vector size.

## Tests

- `UV_CACHE_DIR=/private/tmp/uv-cache-graphrag uv run pytest -q tests/integration/vector_stores/test_lancedb.py -k "load_documents"`
- `UV_CACHE_DIR=/private/tmp/uv-cache-graphrag uv run pytest -q tests/integration/vector_stores/test_lancedb.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-graphrag uv run ruff format --check packages/graphrag-vectors/graphrag_vectors/lancedb.py tests/integration/vector_stores/test_lancedb.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-graphrag uv run ruff check packages/graphrag-vectors/graphrag_vectors/lancedb.py tests/integration/vector_stores/test_lancedb.py`