### PR TITLE
fix: handle blank LanceDB vector store URI

### DIFF
--- a/packages/graphrag/graphrag/config/models/graph_rag_config.py
+++ b/packages/graphrag/graphrag/config/models/graph_rag_config.py
@@ -270,7 +270,7 @@ class GraphRagConfig(BaseModel):
         """Validate the vector store configuration."""
         store = self.vector_store
         if store.type == VectorStoreType.LanceDB:
-            if not store.db_uri or store.db_uri.strip == "":
+            if not store.db_uri or store.db_uri.strip() == "":
                 store.db_uri = graphrag_config_defaults.vector_store.db_uri
             store.db_uri = str(Path(store.db_uri).resolve())
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 from unittest import mock
 
+import graphrag.config.defaults as defs
 from graphrag.config.load_config import load_config
 from graphrag.config.models.graph_rag_config import GraphRagConfig
 
@@ -24,6 +25,19 @@ def test_default_config() -> None:
         embedding_models=DEFAULT_EMBEDDING_MODELS,  # type: ignore
     )
     assert_graphrag_configs(actual, expected)
+
+
+def test_blank_lancedb_uri_uses_default(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    config = GraphRagConfig(
+        completion_models=DEFAULT_COMPLETION_MODELS,  # type: ignore
+        embedding_models=DEFAULT_EMBEDDING_MODELS,  # type: ignore
+        vector_store={"type": "lancedb", "db_uri": " \t "},
+    )
+
+    assert config.vector_store.db_uri == str(
+        (tmp_path / defs.graphrag_config_defaults.vector_store.db_uri).resolve()
+    )
 
 
 @mock.patch.dict(os.environ, {"CUSTOM_API_KEY": FAKE_API_KEY}, clear=True)


### PR DESCRIPTION
## Summary

- call `store.db_uri.strip()` when validating LanceDB vector store configuration
- preserve the intended default `output/lancedb` fallback for whitespace-only `db_uri` values
- add regression coverage so whitespace-only LanceDB URIs no longer resolve to the current working directory

Fixes #2381.

## Tests

- `uv run ruff check packages/graphrag/graphrag/config/models/graph_rag_config.py tests/unit/config/test_config.py`
- `uv run ruff format --check packages/graphrag/graphrag/config/models/graph_rag_config.py tests/unit/config/test_config.py`
- `uv run --package graphrag pytest tests/unit/config/test_config.py -q`
- `git diff --check`
