### PR TITLE
fix: preserve literal dollar signs in config parsing

### DIFF
--- a/packages/graphrag-common/graphrag_common/config/load_config.py
+++ b/packages/graphrag-common/graphrag_common/config/load_config.py
@@ -84,11 +84,12 @@ def _get_parser_for_file(file_path: str | Path) -> Callable[[str], dict[str, Any
 
 def _parse_env_variables(text: str) -> str:
     """Parse environment variables in the configuration text."""
-    try:
-        return Template(text).substitute(os.environ)
-    except KeyError as error:
-        msg = f"Environment variable not found: {error}"
-        raise ConfigParsingError(msg) from error
+    for match in Template.pattern.finditer(text):
+        env_var = match.group("named") or match.group("braced")
+        if env_var is not None and env_var not in os.environ:
+            msg = f"Environment variable not found: {env_var!r}"
+            raise ConfigParsingError(msg)
+    return Template(text).safe_substitute(os.environ)
 
 
 def _recursive_merge_dicts(dest: dict[str, Any], src: dict[str, Any]) -> None:

--- a/tests/unit/load_config/test_load_config.py
+++ b/tests/unit/load_config/test_load_config.py
@@ -155,3 +155,30 @@ def test_load_config():
     assert config_with_env_vars.nested_list[0].nested_int == 7
     assert config_with_env_vars.nested_list[1].nested_str == "list_value_2"
     assert config_with_env_vars.nested_list[1].nested_int == 8
+
+
+def test_load_config_preserves_literal_dollar_signs(tmp_path: Path) -> None:
+    """Literal dollar signs such as regex anchors should not be parsed as env vars."""
+    pattern = r".*\.md$"
+    config_path = tmp_path / "settings.yaml"
+    config_path.write_text(
+        f"""
+name: '{pattern}'
+value: 100
+nested:
+  nested_str: "nested_value"
+  nested_int: 42
+nested_list:
+  - nested_str: "list_value_1"
+    nested_int: 7
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(
+        config_initializer=TestConfigModel,
+        config_path=config_path,
+        set_cwd=False,
+    )
+
+    assert config.name == pattern


### PR DESCRIPTION
## Summary
- preserve literal `$` characters in config values such as regex anchors while still expanding valid environment variables
- keep the existing missing-env-var failure behavior for valid `$VAR` and `${VAR}` placeholders
- add a regression test for a YAML regex pattern ending in `$`

Fixes #2349.

## Root cause
`string.Template.substitute()` treats every `$` as the start of a template placeholder and raises `ValueError` for a bare regex anchor like `.*\.md$`. The loader only needs strict validation for valid env-var placeholders; other `$` characters should remain literal config content.

## Tests
- `uv run --package graphrag-common pytest tests/unit/load_config/test_load_config.py -q`
- `uv run ruff check packages/graphrag-common/graphrag_common/config/load_config.py tests/unit/load_config/test_load_config.py`
- `uv run ruff format --check packages/graphrag-common/graphrag_common/config/load_config.py tests/unit/load_config/test_load_config.py`
- `git diff --check`