### PR TITLE
fix(input): ignore blank lines when reading JSONL files

### DIFF
--- a/.semversioner/next-release/patch-20260705142108838934.json
+++ b/.semversioner/next-release/patch-20260705142108838934.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Ignore blank lines when loading JSONL input files."
+}

--- a/packages/graphrag-input/graphrag_input/jsonl.py
+++ b/packages/graphrag-input/graphrag_input/jsonl.py
@@ -34,5 +34,5 @@ class JSONLinesFileReader(StructuredFileReader):
             - output - list with a TextDocument for each row in the file.
         """
         text = await self._storage.get(path, encoding=self._encoding)
-        rows = [json.loads(line) for line in text.splitlines()]
+        rows = [json.loads(line) for line in text.splitlines() if line.strip()]
         return await self.process_data_columns(rows, path)

--- a/tests/unit/indexing/input/test_jsonl_loader.py
+++ b/tests/unit/indexing/input/test_jsonl_loader.py
@@ -40,3 +40,24 @@ async def test_jsonl_loader_one_file_with_title():
     documents = await reader.read_files()
     assert len(documents) == 3
     assert documents[0].title == "Hello"
+
+
+async def test_jsonl_loader_ignores_blank_lines(tmp_path):
+    (tmp_path / "input.jsonl").write_text(
+        '{"title":"Hello","text":"Hi"}\n\n   \n{"title":"Goodbye","text":"Bye"}\n',
+        encoding="utf-8",
+    )
+    config = InputConfig(
+        type=InputType.JsonLines,
+        title_column="title",
+    )
+    storage = create_storage(
+        StorageConfig(
+            base_dir=str(tmp_path),
+        )
+    )
+    reader = create_input_reader(config, storage)
+    documents = await reader.read_files()
+    assert len(documents) == 2
+    assert [doc.title for doc in documents] == ["Hello", "Goodbye"]
+    assert [doc.text for doc in documents] == ["Hi", "Bye"]


### PR DESCRIPTION
## Description

Fix JSONL input loading so blank or whitespace-only lines do not cause the entire `.jsonl` file to be skipped.

`JSONLinesFileReader.read_file()` currently parses every entry returned by `text.splitlines()` with `json.loads(line)`. When a `.jsonl` file contains a blank line between otherwise valid records, `json.loads("")` raises `JSONDecodeError`. That exception bubbles up to `InputReader._iterate_files()`, which logs the error and skips the whole file.

This change filters out blank or whitespace-only lines before parsing JSONL records, while preserving the existing behavior for non-empty malformed JSON lines.

## Related Issues

Fixes #2424.

## Proposed Changes

- Ignore blank or whitespace-only lines when reading JSONL input files.
- Preserve existing parsing behavior for valid non-empty JSONL records.
- Preserve failure behavior for genuinely malformed non-empty JSONL lines.
- Add a focused unit test covering valid JSONL records separated by blank lines.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).

## Additional Notes

### What Problem This Solves

A JSONL input file may contain accidental blank or whitespace-only lines between otherwise valid records:

```jsonl
{"text":"a"}

{"text":"b"}
```

Before this change, the blank line was passed directly to `json.loads("")`, which raises `JSONDecodeError`. Because `InputReader._iterate_files()` catches exceptions at the file level, the reader skipped the entire file instead of loading the valid records before and after the blank line.

### Evidence

The affected call chain is:

```text
create_input_reader(...)
  -> JSONLinesFileReader.read_file(...)
    -> text.splitlines()
    -> json.loads(line)
       -> JSONDecodeError on blank line
  -> InputReader._iterate_files(...)
    -> catches exception
    -> logs warning
    -> skips the file
```

This PR only ignores blank or whitespace-only JSONL lines. Malformed non-empty lines still go through `json.loads(line)` and keep the existing error/skip behavior.

### Scope

This change only affects JSONL input handling. It does not change CSV, JSON, text, parquet, MarkItDown, storage behavior, or handling of malformed non-empty JSONL records.

### Validation

- `git diff --check`
- `uv run ruff format --check packages/graphrag-input/graphrag_input/jsonl.py tests/unit/indexing/input/test_jsonl_loader.py`
- `uv run ruff check packages/graphrag-input/graphrag_input/jsonl.py tests/unit/indexing/input/test_jsonl_loader.py`
- `uv run --package graphrag-input pytest tests/unit/indexing/input/test_jsonl_loader.py -q` - 3 passed

