### PR TITLE
Fix cannot release un-acquired lock in Blob logger

### DIFF
--- a/.semversioner/next-release/patch-20260717165805703786.json
+++ b/.semversioner/next-release/patch-20260717165805703786.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Fix 2170 - cannot release un-acquired lock in Blob logger"
+}

--- a/packages/graphrag/graphrag/logger/blob_workflow_logger.py
+++ b/packages/graphrag/graphrag/logger/blob_workflow_logger.py
@@ -6,7 +6,6 @@
 import json
 import logging
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any
 
 from azure.identity import DefaultAzureCredential
@@ -97,6 +96,7 @@ class BlobWorkflowLogger(logging.Handler):
         if self._base_dir:
             blob_path = f"{self._base_dir.strip('/')}/{blob_path}"
         self._blob_name = blob_path
+        self._blob_client = self._blob_service_client.get_blob_client(
             self._container_name, self._blob_name
         )
         if not self._blob_client.exists():

--- a/packages/graphrag/graphrag/logger/blob_workflow_logger.py
+++ b/packages/graphrag/graphrag/logger/blob_workflow_logger.py
@@ -41,6 +41,7 @@ class BlobWorkflowLogger(logging.Handler):
 
         self._connection_string = connection_string
         self.account_url = account_url
+        self._base_dir = base_dir
 
         if self._connection_string:
             self._blob_service_client = BlobServiceClient.from_connection_string(
@@ -56,18 +57,8 @@ class BlobWorkflowLogger(logging.Handler):
                 credential=DefaultAzureCredential(),
             )
 
-        if blob_name == "":
-            blob_name = f"report/{datetime.now(tz=timezone.utc).strftime('%Y-%m-%d-%H:%M:%S:%f')}.logs.json"
-
-        self._blob_name = str(Path(base_dir or "") / blob_name)
         self._container_name = container_name
-        self._blob_client = self._blob_service_client.get_blob_client(
-            self._container_name, self._blob_name
-        )
-        if not self._blob_client.exists():
-            self._blob_client.create_append_blob()
-
-        self._num_blocks = 0  # refresh block counter
+        self._rotate_blob(blob_name or None)
 
     def emit(self, record) -> None:
         """Emit a log record to blob storage."""
@@ -98,17 +89,24 @@ class BlobWorkflowLogger(logging.Handler):
             return "warning"
         return "log"
 
+    def _rotate_blob(self, blob_name: str | None = None):
+        """Create a new blob file when the current one reaches max block count."""
+        if not blob_name:
+            blob_name = f"report/{datetime.now(tz=timezone.utc).strftime('%Y-%m-%d-%H:%M:%S:%f')}.logs.json"
+        self._blob_name = str(Path(self._base_dir or "") / blob_name)
+        self._blob_client = self._blob_service_client.get_blob_client(
+            self._container_name, self._blob_name
+        )
+        if not self._blob_client.exists():
+            self._blob_client.create_append_blob()
+        self._num_blocks = 0
+
     def _write_log(self, log: dict[str, Any]):
         """Write log data to blob storage."""
         # create a new file when block count hits close 25k
-        if (
-            self._num_blocks >= self._max_block_count
-        ):  # Check if block count exceeds 25k
-            self.__init__(
-                self._connection_string,
-                self._container_name,
-                account_url=self.account_url,
-            )
+
+        if self._num_blocks >= self._max_block_count:
+            self._rotate_blob()
 
         blob_client = self._blob_service_client.get_blob_client(
             self._container_name, self._blob_name

--- a/packages/graphrag/graphrag/logger/blob_workflow_logger.py
+++ b/packages/graphrag/graphrag/logger/blob_workflow_logger.py
@@ -93,8 +93,10 @@ class BlobWorkflowLogger(logging.Handler):
         """Create a new blob file when the current one reaches max block count."""
         if not blob_name:
             blob_name = f"report/{datetime.now(tz=timezone.utc).strftime('%Y-%m-%d-%H:%M:%S:%f')}.logs.json"
-        self._blob_name = str(Path(self._base_dir or "") / blob_name)
-        self._blob_client = self._blob_service_client.get_blob_client(
+        blob_path = blob_name.lstrip("/")
+        if self._base_dir:
+            blob_path = f"{self._base_dir.strip('/')}/{blob_path}"
+        self._blob_name = blob_path
             self._container_name, self._blob_name
         )
         if not self._blob_client.exists():

--- a/tests/unit/logger/__init__.py
+++ b/tests/unit/logger/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License

--- a/tests/unit/logger/test_blob_workflow_logger.py
+++ b/tests/unit/logger/test_blob_workflow_logger.py
@@ -4,7 +4,6 @@
 """Unit tests for the BlobWorkflowLogger."""
 
 import json
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -81,7 +80,7 @@ def test_init_uses_provided_blob_name(mock_blob_service, mock_credential):
     """Test that the provided blob name is honored and nested under base_dir."""
     logger = _make_logger()
 
-    assert logger._blob_name == str(Path("logs") / "test.logs.json")  # noqa: SLF001
+    assert logger._blob_name == "logs/test.logs.json"  # noqa: SLF001
 
 
 def test_rotate_blob_does_not_reinitialize_handler(mock_blob_service, mock_credential):

--- a/tests/unit/logger/test_blob_workflow_logger.py
+++ b/tests/unit/logger/test_blob_workflow_logger.py
@@ -4,6 +4,7 @@
 """Unit tests for the BlobWorkflowLogger."""
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -80,7 +81,7 @@ def test_init_uses_provided_blob_name(mock_blob_service, mock_credential):
     """Test that the provided blob name is honored and nested under base_dir."""
     logger = _make_logger()
 
-    assert logger._blob_name == "logs/test.logs.json"  # noqa: SLF001
+    assert logger._blob_name == str(Path("logs") / "test.logs.json")  # noqa: SLF001
 
 
 def test_rotate_blob_does_not_reinitialize_handler(mock_blob_service, mock_credential):

--- a/tests/unit/logger/test_blob_workflow_logger.py
+++ b/tests/unit/logger/test_blob_workflow_logger.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""Unit tests for the BlobWorkflowLogger."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from graphrag.logger.blob_workflow_logger import BlobWorkflowLogger
+
+
+@pytest.fixture
+def mock_blob_service():
+    """Create a mock BlobServiceClient and related objects."""
+    with patch(
+        "graphrag.logger.blob_workflow_logger.BlobServiceClient"
+    ) as mock_bsc_cls:
+        mock_blob_client = MagicMock()
+        mock_blob_client.exists.return_value = False
+
+        mock_bsc = MagicMock()
+        mock_bsc.get_blob_client.return_value = mock_blob_client
+
+        mock_bsc_cls.return_value = mock_bsc
+
+        yield mock_bsc, mock_blob_client
+
+
+@pytest.fixture
+def mock_credential():
+    """Mock DefaultAzureCredential."""
+    with patch(
+        "graphrag.logger.blob_workflow_logger.DefaultAzureCredential"
+    ) as mock_cred:
+        yield mock_cred
+
+
+def _make_logger() -> BlobWorkflowLogger:
+    return BlobWorkflowLogger(
+        connection_string=None,
+        container_name="test-container",
+        blob_name="test.logs.json",
+        base_dir="logs",
+        account_url="https://test.blob.core.windows.net",
+    )
+
+
+def test_init_requires_container_name(mock_credential):
+    """Test that a missing container name raises a ValueError."""
+    with pytest.raises(ValueError, match="No container name provided"):
+        BlobWorkflowLogger(
+            connection_string=None,
+            container_name=None,
+            account_url="https://test.blob.core.windows.net",
+        )
+
+
+def test_init_requires_connection_or_account_url():
+    """Test that missing both connection string and account url raises."""
+    with pytest.raises(ValueError, match="No storage account blob url provided"):
+        BlobWorkflowLogger(
+            connection_string=None,
+            container_name="test-container",
+        )
+
+
+def test_init_creates_append_blob(mock_blob_service, mock_credential):
+    """Test that a new append blob is created on initialization."""
+    _mock_bsc, mock_blob_client = mock_blob_service
+
+    logger = _make_logger()
+
+    mock_blob_client.create_append_blob.assert_called_once()
+    assert logger._num_blocks == 0  # noqa: SLF001
+    assert logger._base_dir == "logs"  # noqa: SLF001
+
+
+def test_init_uses_provided_blob_name(mock_blob_service, mock_credential):
+    """Test that the provided blob name is honored and nested under base_dir."""
+    logger = _make_logger()
+
+    assert logger._blob_name == "logs/test.logs.json"  # noqa: SLF001
+
+
+def test_rotate_blob_does_not_reinitialize_handler(mock_blob_service, mock_credential):
+    """Test that blob rotation does not call __init__ on the handler.
+
+    This verifies the fix for issue #2170 where calling self.__init__()
+    during rotation caused 'cannot release un-acquired lock' errors.
+    """
+    mock_bsc, _mock_blob_client = mock_blob_service
+
+    logger = _make_logger()
+
+    # Simulate reaching max block count
+    logger._num_blocks = logger._max_block_count  # noqa: SLF001
+
+    # Store reference to the original lock to verify it's not replaced
+    original_lock = logger.lock
+
+    # Write a log entry, which should trigger rotation
+    logger._write_log({"type": "log", "data": "test message"})  # noqa: SLF001
+
+    # Verify the lock was NOT replaced (i.e., __init__ was not called)
+    assert logger.lock is original_lock
+
+    # Verify block counter was reset (rotation happened)
+    # After rotation (reset to 0) + 1 write = 1
+    assert logger._num_blocks == 1  # noqa: SLF001
+
+    # Verify a new blob client was created during rotation
+    assert mock_bsc.get_blob_client.call_count > 1
+
+
+def test_rotate_blob_creates_new_blob_name(mock_blob_service, mock_credential):
+    """Test that rotation generates a new blob name."""
+    _mock_bsc, _mock_blob_client = mock_blob_service
+
+    logger = _make_logger()
+
+    original_blob_name = logger._blob_name  # noqa: SLF001
+
+    # Trigger rotation
+    logger._rotate_blob()  # noqa: SLF001
+
+    # New blob name should be different (auto-generated with timestamp)
+    assert logger._blob_name != original_blob_name  # noqa: SLF001
+    assert logger._num_blocks == 0  # noqa: SLF001
+
+
+def test_write_log_appends_block(mock_blob_service, mock_credential):
+    """Test that writing a log appends an encoded block and increments count."""
+    _mock_bsc, mock_blob_client = mock_blob_service
+
+    logger = _make_logger()
+
+    logger._write_log({"type": "log", "data": "hello"})  # noqa: SLF001
+
+    mock_blob_client.append_block.assert_called_once()
+    (payload,), _kwargs = mock_blob_client.append_block.call_args
+    decoded = json.loads(payload.decode("utf-8"))
+    assert decoded == {"type": "log", "data": "hello"}
+    assert logger._num_blocks == 1  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    ("level", "expected"),
+    [
+        (logging_level, expected)
+        for logging_level, expected in [
+            (40, "error"),  # logging.ERROR
+            (30, "warning"),  # logging.WARNING
+            (20, "log"),  # logging.INFO
+            (10, "log"),  # logging.DEBUG
+        ]
+    ],
+)
+def test_get_log_type(mock_blob_service, mock_credential, level, expected):
+    """Test that log levels map to the correct log type string."""
+    logger = _make_logger()
+
+    assert logger._get_log_type(level) == expected  # noqa: SLF001


### PR DESCRIPTION
## Description

Fixes a crash in [BlobWorkflowLogger](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) where [base_dir](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) was accepted in [__init__](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) but never stored, causing [_rotate_blob](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to fail on [self._base_dir](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). Also cleans up indentation in [_write_log](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and adds unit test coverage for the logger.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation (if necessary).
- [x] I have added appropriate unit tests (if applicable).
