### PR TITLE
Fix two docstring mismatches in ConversationHistory.build_context

### DIFF
--- a/packages/graphrag/graphrag/query/context_builder/conversation_history.py
+++ b/packages/graphrag/graphrag/query/context_builder/conversation_history.py
@@ -161,8 +161,8 @@ class ConversationHistory:
 
         Parameters
         ----------
-            user_queries_only: If True, only user queries (not assistant responses) will be included in the context, default is True.
-            max_qa_turns: Maximum number of QA turns to include in the context, default is 1.
+            include_user_turns_only: If True, only user queries (not assistant responses) will be included in the context, default is True.
+            max_qa_turns: Maximum number of QA turns to include in the context, default is 5.
             recency_bias: If True, reverse the order of the conversation history to ensure last QA got prioritized.
             column_delimiter: Delimiter to use for separating columns in the context data, default is "|".
             context_name: Name of the context, default is "Conversation History".


### PR DESCRIPTION
## Description

Two things in the `ConversationHistory.build_context` docstring do not match the signature.

```python
def build_context(
    self,
    tokenizer: Tokenizer | None = None,
    include_user_turns_only: bool = True,
    max_qa_turns: int | None = 5,
    ...
):
    """
    Parameters
    ----------
        user_queries_only: If True, only user queries ... default is True.
        max_qa_turns: Maximum number of QA turns to include in the context, default is 1.
```

`user_queries_only` does not exist, the parameter is `include_user_turns_only` and that is the name used in the body. And `max_qa_turns` is documented as defaulting to 1 while the signature says 5, so anyone relying on the docstring gets the truncation point wrong.

## Related Issues

None.

## Proposed Changes

- `user_queries_only` renamed to `include_user_turns_only`
- documented default for `max_qa_turns` corrected from 1 to 5

## Checklist

- [x] I have tested these changes locally. Docstring text only, nothing to run.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary). This is the documentation.
- [ ] I have added appropriate unit tests (if applicable). Not applicable.

## Additional Notes

`tokenizer` and `max_context_tokens` are not documented at all, which is a separate thing and I left it alone
